### PR TITLE
Stabilize uv temp/cache dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ __pycache__
 .ruff_cache
 .mypy_cache
 .pytest_cache
+.uv-cache
+.uv-tmp
 
 # Logs
 pnpm-debug.log*

--- a/Agent.md
+++ b/Agent.md
@@ -41,6 +41,7 @@
 ## 開発/検証コマンド
 - Web:
   - `pnpm -C apps/web dev --port 3001`
+  - `XDG_RUNTIME_DIR=.xdg-runtime just web` (justが権限エラーになる場合)
   - `pnpm -C apps/web typecheck`
 - API:
   - `uv run uvicorn apps.api.main:app --reload --port 8000`
@@ -51,6 +52,7 @@
 - Mol*は`Viewer.create`を使い、PDB読み込み後に`ball-and-stick`表現を追加
 - Import/Exportの入出力は`.in` (QE) と座標/原子種に限定
 - `apps/web/src/components/molstar/MolstarViewer.tsx` が表示の中心
+- pnpmストアは `/home/grace/projects/chem-model-edit/.pnpm-store` を共通利用する方針（`.pnpm-store` はgit ignore）
 
 ## 進め方のベストプラクティス
 - 変更前に影響範囲と対象ファイルを明確化

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,6 @@
 set shell := ["bash", "-cu"]
 uv_cache_dir := ".uv-cache"
+uv_tmp_dir := ".uv-tmp"
 web_port := "3001"
 api_port := "8000"
 
@@ -69,8 +70,9 @@ api:
     echo "API_PORT $initial_port は使用中のため $port を利用します"
   fi
   cd apps/api
-  UV_CACHE_DIR={{uv_cache_dir}} uv sync
-  UV_CACHE_DIR={{uv_cache_dir}} uv run uvicorn main:app --reload --port "$port"
+  mkdir -p {{uv_cache_dir}} {{uv_tmp_dir}}
+  TMPDIR={{uv_tmp_dir}} UV_CACHE_DIR={{uv_cache_dir}} uv sync
+  TMPDIR={{uv_tmp_dir}} UV_CACHE_DIR={{uv_cache_dir}} uv run uvicorn main:app --reload --port "$port"
 
 dev:
   #!/usr/bin/env bash
@@ -110,8 +112,9 @@ dev:
     echo "WEB_PORT $initial_web_port は使用中のため $web_port を利用します"
   fi
   pushd apps/api >/dev/null
-  UV_CACHE_DIR={{uv_cache_dir}} uv sync
-  UV_CACHE_DIR={{uv_cache_dir}} uv run uvicorn main:app --reload --port "$api_port" &
+  mkdir -p {{uv_cache_dir}} {{uv_tmp_dir}}
+  TMPDIR={{uv_tmp_dir}} UV_CACHE_DIR={{uv_cache_dir}} uv sync
+  TMPDIR={{uv_tmp_dir}} UV_CACHE_DIR={{uv_cache_dir}} uv run uvicorn main:app --reload --port "$api_port" &
   popd >/dev/null
   pnpm -C apps/web dev --port "$web_port" &
   wait


### PR DESCRIPTION
## Summary\n- Justfileでuv実行時にTMPDIR/UV_CACHE_DIRを固定\n- .uv-cache/.uv-tmpをgitignoreに追加\n\n## Testing\n- TMPDIR=/.../.uv-tmp UV_CACHE_DIR=/.../.uv-cache uv sync