### PR TITLE
chore: use codex uv cache paths in Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,7 @@
 set shell := ["bash", "-cu"]
-uv_cache_dir := ".uv-cache"
-uv_tmp_dir := ".uv-tmp"
+# Codexサンドボックスでのrename制限回避のため、書き込み可能な固定パスを使用する
+uv_cache_dir := "/home/grace/.codex/uv-cache"
+uv_tmp_dir := "/home/grace/.codex/uv-tmp"
 web_port := "3001"
 api_port := "8000"
 


### PR DESCRIPTION
## Summary
- set uv cache/tmp dirs to /home/grace/.codex for sandbox usage

## Rationale
- uv sync fails under workspace-write due to rename restrictions; fixed paths keep configuration explicit

## Testing
- not run (config change only)