### PR TITLE
docs: record uv sandbox rename limitation

### DIFF
--- a/Agent.md
+++ b/Agent.md
@@ -53,6 +53,7 @@
 - Import/Exportの入出力は`.in` (QE) と座標/原子種に限定
 - `apps/web/src/components/molstar/MolstarViewer.tsx` が表示の中心
 - pnpmストアは `/home/grace/projects/chem-model-edit/.pnpm-store` を共通利用する方針（`.pnpm-store` はgit ignore）
+- Codexサンドボックス（workspace-write）では `uv sync` が rename 制限で失敗するため、uv 実行時は昇格（on-request）か danger-full-access が必要
 
 ## 進め方のベストプラクティス
 - 変更前に影響範囲と対象ファイルを明確化

--- a/investigations/sandbox-uv-issue.md
+++ b/investigations/sandbox-uv-issue.md
@@ -1,0 +1,26 @@
+# Codexサンドボックスでのuv/just実行問題
+
+## 問題
+- Codex CLI の `sandbox_mode=workspace-write` 環境で `uv sync` が失敗する。
+- `just api` / `just dev` 実行時に uv が内部で行う rename が `Invalid cross-device link (os error 18)` になり停止。
+
+## 原因
+- サンドボックス内でディレクトリ跨ぎの rename が制限されている。
+- `writable_roots` や `--add-dir` は「書き込み許可」の追加であり、rename 制限（EXDEV）は解消しない。
+
+## やったこと
+- 新規 worktree を作成して再現確認。
+- `uv sync` 実行時に `.uv-cache/.tmp* -> .uv-cache/archive-v0/*` の rename で失敗することを確認。
+- `--no-cache` でも `.uv-tmp/.tmp* -> .uv-tmp/*/archive-v0/*` の rename で失敗することを確認。
+- `os.rename` の簡易テストで、同一ディレクトリ内の rename は成功・ディレクトリ跨ぎで EXDEV になることを確認。
+- `UV_CACHE_DIR` / `TMPDIR` を `/home/grace/.codex` 配下に固定し、`writable_roots` / `--add-dir` を試すも EXDEV は解消せず。
+- `danger-full-access` または昇格（on-request）では `uv sync` が成功することを確認。
+
+## 結果
+- 根本原因はサンドボックスの rename 制限（EXDEV）。
+- `writable_roots` 追加のみでは uv の rename 問題を解決できない。
+
+## 対応方針
+- uv を使う作業は昇格（on-request）で実行する。
+- もしくは `danger-full-access` で作業する。
+- `Justfile` は `/home/grace/.codex/uv-cache` / `/home/grace/.codex/uv-tmp` を参照する前提で運用（ただし昇格が必要）。


### PR DESCRIPTION
## Summary
- document uv/just sandbox rename failure and elevation requirement
- add investigation log under investigations/

## Testing
- not run (docs only)