### PR TITLE
Fix ase_read typing for mypy

### DIFF
--- a/apps/api/services/transplant.py
+++ b/apps/api/services/transplant.py
@@ -6,11 +6,13 @@ import math
 import re
 from typing import Any, Callable, List, Tuple
 
-ase_read: Callable[..., Any] | None
+_ase_read: Callable[..., Any] | None
 try:
-    from ase.io import read as ase_read
+    from ase.io import read as _ase_read
 except Exception:
-    ase_read = None
+    _ase_read = None
+
+ase_read: Callable[..., Any] | None = _ase_read
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Make the `ase_read` try/except import explicitly Optional to satisfy mypy (avoids `no-redef` and assignment mismatch).

## Tests
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest`