### PR TITLE
Split ZPE compute plane and add E2E coverage

### DIFF
--- a/apps/api/models.py
+++ b/apps/api/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from pydantic import BaseModel, Field
 
@@ -108,3 +108,82 @@ class SupercellMeta(BaseModel):
 class SupercellResponse(BaseModel):
     structure: Structure
     meta: SupercellMeta
+
+
+class ZPEParseRequest(BaseModel):
+    content: str
+
+
+class ZPEParseResponse(BaseModel):
+    structure: Structure
+    fixed_indices: List[int]
+    atomic_species: Dict[str, str] = Field(default_factory=dict)
+    kpoints: Optional[Tuple[int, int, int]] = None
+
+
+class ZPEJobRequest(BaseModel):
+    content: str
+    mobile_indices: List[int]
+    use_environ: bool = False
+    input_dir: Optional[str] = None
+    calc_mode: str = "continue"
+
+
+class ZPEJobResponse(BaseModel):
+    job_id: str
+
+
+class ZPEJobStatusResponse(BaseModel):
+    status: str
+    detail: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+class ZPEResult(BaseModel):
+    freqs_cm: List[float]
+    zpe_ev: float
+    s_vib_jmol_k: float
+    mobile_indices: List[int]
+    fixed_indices: List[int]
+    kpts: Tuple[int, int, int]
+    delta: float
+    low_cut_cm: float
+    temperature: float
+    use_environ: bool
+    qe_input: str
+    pseudo_dir: str
+    calc_start_time: str
+    calc_end_time: str
+    elapsed_seconds: float
+    cache_checked: int
+    cache_deleted: int
+    ecutwfc: Optional[float] = None
+    ecutrho: Optional[float] = None
+
+
+class ZPEJobResultResponse(BaseModel):
+    result: ZPEResult
+
+
+class ZPEEnrollTokenRequest(BaseModel):
+    ttl_seconds: Optional[int] = None
+    label: Optional[str] = None
+
+
+class ZPEEnrollTokenResponse(BaseModel):
+    token: str
+    expires_at: str
+    ttl_seconds: int
+    label: Optional[str] = None
+
+
+class ZPEComputeRegisterRequest(BaseModel):
+    token: str
+    name: Optional[str] = None
+    meta: Dict[str, str] = Field(default_factory=dict)
+
+
+class ZPEComputeRegisterResponse(BaseModel):
+    server_id: str
+    registered_at: str
+    name: Optional[str] = None

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -22,3 +22,8 @@ dev = [
     "pytest>=9.0.2",
     "ruff>=0.14.10",
 ]
+
+[tool.pytest.ini_options]
+markers = [
+    "e2e: end-to-end tests that require external dependencies (QE, pseudopotentials)",
+]

--- a/apps/api/services/zpe/__init__.py
+++ b/apps/api/services/zpe/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from .backends import enqueue_zpe_job
+from .enroll import ComputeEnrollStore, EnrollToken, get_enroll_store
 from .paths import resolve_job_file, resolve_pseudo_dir, resolve_work_dir
 from .parse import (
     ensure_mobile_indices,
@@ -11,14 +13,20 @@ from .parse import (
     parse_qe_structure,
 )
 from .queue import fetch_job, get_queue, get_redis_connection
+from .result_store import get_result_store
 from .settings import ZPESettings, get_zpe_settings
 
 __all__ = [
     "ZPESettings",
     "ensure_mobile_indices",
+    "enqueue_zpe_job",
+    "EnrollToken",
+    "ComputeEnrollStore",
     "extract_fixed_indices",
     "fetch_job",
+    "get_enroll_store",
     "get_queue",
+    "get_result_store",
     "get_redis_connection",
     "get_zpe_settings",
     "parse_atomic_species",

--- a/apps/api/services/zpe/backends.py
+++ b/apps/api/services/zpe/backends.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Dict, Any
+from uuid import uuid4
+
+from models import ZPEJobRequest
+from .io import format_freqs_csv, format_summary
+from .parse import extract_fixed_indices, parse_kpoints_automatic
+from .queue import get_queue
+from .result_store import ResultStore, get_result_store
+from .settings import get_zpe_settings
+from .thermo import calc_zpe_and_s_vib, normalize_frequencies
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _default_kpts() -> tuple[int, int, int]:
+    return (1, 1, 1)
+
+
+def enqueue_zpe_job(payload: Dict[str, Any]) -> str:
+    settings = get_zpe_settings()
+    store = get_result_store()
+    if settings.compute_mode == "remote-queue":
+        job = get_queue().enqueue(
+            "services.zpe.worker.run_zpe_job",
+            payload,
+            job_timeout=settings.job_timeout_seconds,
+            result_ttl=settings.result_ttl_seconds,
+        )
+        store.set_status(job.id, "queued")
+        return job.id
+    if settings.compute_mode == "local":
+        from .worker import run_zpe_job
+
+        job_id = f"local-{uuid4().hex}"
+        payload = {**payload, "job_id": job_id}
+        run_zpe_job(payload)
+        return job_id
+    if settings.compute_mode == "mock":
+        return _run_mock_job(payload, store)
+    raise ValueError("compute_mode は local / remote-queue / mock のいずれかです。")
+
+
+def _run_mock_job(payload: Dict[str, Any], store: ResultStore) -> str:
+    request = ZPEJobRequest(**payload)
+    job_id = f"mock-{uuid4().hex}"
+    store.set_status(job_id, "started")
+
+    fixed_indices = extract_fixed_indices(request.content)
+    kpts = parse_kpoints_automatic(request.content)
+    kpts_use = kpts[0] if kpts else _default_kpts()
+
+    nfreq = max(1, len(request.mobile_indices) * 3)
+    freqs_cm = [100.0 + 5.0 * i for i in range(nfreq)]
+    zpe_ev, s_vib_jmol_k = calc_zpe_and_s_vib(
+        freqs_cm,
+        low_cut_cm=get_zpe_settings().low_cut_cm,
+        temperature=get_zpe_settings().temperature,
+    )
+
+    now = _now_iso()
+    result: Dict[str, Any] = {
+        "freqs_cm": normalize_frequencies(freqs_cm),
+        "zpe_ev": zpe_ev,
+        "s_vib_jmol_k": s_vib_jmol_k,
+        "mobile_indices": request.mobile_indices,
+        "fixed_indices": fixed_indices,
+        "kpts": kpts_use,
+        "delta": get_zpe_settings().delta,
+        "low_cut_cm": get_zpe_settings().low_cut_cm,
+        "temperature": get_zpe_settings().temperature,
+        "use_environ": request.use_environ,
+        "qe_input": "mock",
+        "pseudo_dir": "mock",
+        "calc_start_time": now,
+        "calc_end_time": now,
+        "elapsed_seconds": 0.0,
+        "cache_checked": 0,
+        "cache_deleted": 0,
+        "ecutwfc": None,
+        "ecutrho": None,
+    }
+
+    summary_text = format_summary(
+        result,
+        pseudo_dir="mock",
+        qe_input="mock",
+        new_calc=request.calc_mode == "new",
+    )
+    freqs_csv = format_freqs_csv(freqs_cm)
+    store.set_result(job_id, result, summary_text=summary_text, freqs_csv=freqs_csv)
+    store.set_status(job_id, "finished")
+    return job_id

--- a/apps/api/services/zpe/enroll.py
+++ b/apps/api/services/zpe/enroll.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+import json
+import secrets
+from typing import Dict, Optional, cast
+from uuid import uuid4
+
+from redis import Redis
+
+from .queue import get_redis_connection
+from .settings import get_zpe_settings
+
+
+_ENROLL_PREFIX = "zpe:enroll:"
+_SERVER_PREFIX = "zpe:compute:server:"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _now_iso() -> str:
+    return _now().isoformat()
+
+
+def _expires_iso(ttl_seconds: int) -> str:
+    return (_now() + timedelta(seconds=ttl_seconds)).isoformat()
+
+
+@dataclass
+class EnrollToken:
+    token: str
+    expires_at: str
+    ttl_seconds: int
+    label: Optional[str] = None
+
+
+@dataclass
+class ComputeServerRegistration:
+    server_id: str
+    registered_at: str
+    name: Optional[str] = None
+    meta: Dict[str, str] = field(default_factory=dict)
+
+
+class ComputeEnrollStore:
+    def __init__(self, redis: Optional[Redis] = None) -> None:
+        self.redis = redis or get_redis_connection()
+
+    def create_token(
+        self,
+        *,
+        ttl_seconds: Optional[int] = None,
+        label: Optional[str] = None,
+    ) -> EnrollToken:
+        settings = get_zpe_settings()
+        ttl = ttl_seconds if ttl_seconds is not None else settings.enroll_token_ttl_seconds
+        if ttl <= 0:
+            raise ValueError("ttl_seconds must be >= 1")
+        token = secrets.token_urlsafe(32)
+        payload = {
+            "created_at": _now_iso(),
+            "label": label or "",
+        }
+        key = f"{_ENROLL_PREFIX}{token}"
+        self.redis.hset(key, mapping=payload)
+        self.redis.expire(key, ttl)
+        return EnrollToken(
+            token=token,
+            expires_at=_expires_iso(ttl),
+            ttl_seconds=ttl,
+            label=label,
+        )
+
+    def consume_token(
+        self,
+        token: str,
+        *,
+        name: Optional[str] = None,
+        meta: Optional[Dict[str, str]] = None,
+    ) -> ComputeServerRegistration:
+        key = f"{_ENROLL_PREFIX}{token}"
+        deleted = cast(int, self.redis.delete(key))
+        if deleted == 0:
+            raise KeyError("token not found")
+        server_id = f"compute-{uuid4().hex}"
+        now = _now_iso()
+        payload = {
+            "registered_at": now,
+            "name": name or "",
+        }
+        if meta:
+            payload["meta"] = json.dumps(meta, ensure_ascii=False)
+        self.redis.hset(f"{_SERVER_PREFIX}{server_id}", mapping=payload)
+        return ComputeServerRegistration(
+            server_id=server_id,
+            registered_at=now,
+            name=name,
+            meta=meta or {},
+        )
+
+
+def get_enroll_store() -> ComputeEnrollStore:
+    return ComputeEnrollStore()

--- a/apps/api/services/zpe/io.py
+++ b/apps/api/services/zpe/io.py
@@ -7,14 +7,13 @@ from typing import Dict, Iterable
 import numpy as np
 
 
-def write_summary(
-    path: Path,
+def format_summary(
     result: Dict[str, object],
     *,
     pseudo_dir: str,
     qe_input: str,
     new_calc: bool,
-) -> None:
+) -> str:
     lines = [
         "# ZPE summary (ASE Vibrations)",
         f"calc_start_time: {result['calc_start_time']}",
@@ -34,14 +33,32 @@ def write_summary(
         f"cache_checked: {result['cache_checked']}",
         f"cache_deleted: {result['cache_deleted']}",
     ]
-    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return "\n".join(lines) + "\n"
 
 
-def write_freqs_csv(path: Path, freqs_cm: Iterable[float]) -> None:
+def write_summary(
+    path: Path,
+    result: Dict[str, object],
+    *,
+    pseudo_dir: str,
+    qe_input: str,
+    new_calc: bool,
+) -> None:
+    path.write_text(
+        format_summary(result, pseudo_dir=pseudo_dir, qe_input=qe_input, new_calc=new_calc),
+        encoding="utf-8",
+    )
+
+
+def format_freqs_csv(freqs_cm: Iterable[float]) -> str:
     lines = ["frequency_cm^-1"]
     for freq in freqs_cm:
         lines.append(f"{float(np.real(freq)):.6f}")
-    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return "\n".join(lines) + "\n"
+
+
+def write_freqs_csv(path: Path, freqs_cm: Iterable[float]) -> None:
+    path.write_text(format_freqs_csv(freqs_cm), encoding="utf-8")
 
 
 def write_result_json(path: Path, result: Dict[str, object]) -> None:

--- a/apps/api/services/zpe/result_store.py
+++ b/apps/api/services/zpe/result_store.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+from typing import Any, Dict, Optional, cast
+
+from redis import Redis
+
+from .queue import get_redis_connection
+from .settings import get_zpe_settings
+
+
+@dataclass
+class ZPEJobStatus:
+    status: str
+    detail: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+_STATUS_PREFIX = "zpe:status:"
+_RESULT_PREFIX = "zpe:result:"
+_SUMMARY_PREFIX = "zpe:summary:"
+_FREQS_PREFIX = "zpe:freqs:"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _decode(value: Optional[bytes]) -> Optional[str]:
+    if value is None:
+        return None
+    return value.decode("utf-8")
+
+
+def _decode_dict(data: Dict[bytes, bytes]) -> Dict[str, str]:
+    return {k.decode("utf-8"): v.decode("utf-8") for k, v in data.items()}
+
+
+class ResultStore:
+    def set_status(self, job_id: str, status: str, detail: Optional[str] = None) -> None:
+        raise NotImplementedError
+
+    def get_status(self, job_id: str) -> ZPEJobStatus:
+        raise NotImplementedError
+
+    def set_result(
+        self,
+        job_id: str,
+        result: Dict[str, Any],
+        *,
+        summary_text: str,
+        freqs_csv: str,
+    ) -> None:
+        raise NotImplementedError
+
+    def get_result(self, job_id: str) -> Dict[str, Any]:
+        raise NotImplementedError
+
+    def get_file(self, job_id: str, kind: str) -> str:
+        raise NotImplementedError
+
+
+class RedisResultStore(ResultStore):
+    def __init__(self, redis: Optional[Redis] = None) -> None:
+        self.redis = redis or get_redis_connection()
+        self.ttl = get_zpe_settings().result_ttl_seconds
+
+    def set_status(self, job_id: str, status: str, detail: Optional[str] = None) -> None:
+        key = f"{_STATUS_PREFIX}{job_id}"
+        payload = {
+            "status": status,
+            "detail": detail or "",
+            "updated_at": _now_iso(),
+        }
+        self.redis.hset(key, mapping=payload)
+        self.redis.expire(key, self.ttl)
+
+    def get_status(self, job_id: str) -> ZPEJobStatus:
+        key = f"{_STATUS_PREFIX}{job_id}"
+        data = cast(Dict[bytes, bytes], self.redis.hgetall(key))
+        if not data:
+            raise KeyError("status not found")
+        decoded = _decode_dict(data)
+        return ZPEJobStatus(
+            status=decoded.get("status", "unknown"),
+            detail=decoded.get("detail") or None,
+            updated_at=decoded.get("updated_at"),
+        )
+
+    def set_result(
+        self,
+        job_id: str,
+        result: Dict[str, Any],
+        *,
+        summary_text: str,
+        freqs_csv: str,
+    ) -> None:
+        self.redis.setex(f"{_RESULT_PREFIX}{job_id}", self.ttl, json.dumps(result))
+        self.redis.setex(f"{_SUMMARY_PREFIX}{job_id}", self.ttl, summary_text)
+        self.redis.setex(f"{_FREQS_PREFIX}{job_id}", self.ttl, freqs_csv)
+
+    def get_result(self, job_id: str) -> Dict[str, Any]:
+        raw = cast(Optional[bytes], self.redis.get(f"{_RESULT_PREFIX}{job_id}"))
+        if raw is None:
+            raise KeyError("result not found")
+        return json.loads(raw)
+
+    def get_file(self, job_id: str, kind: str) -> str:
+        if kind == "summary":
+            key = f"{_SUMMARY_PREFIX}{job_id}"
+        elif kind == "freqs":
+            key = f"{_FREQS_PREFIX}{job_id}"
+        else:
+            raise ValueError("kind は summary / freqs のいずれかです。")
+        raw = cast(Optional[bytes], self.redis.get(key))
+        if raw is None:
+            raise KeyError("file not found")
+        return _decode(raw) or ""
+
+
+def get_result_store() -> ResultStore:
+    settings = get_zpe_settings()
+    if settings.result_store != "redis":
+        raise ValueError("result_store は redis のみ対応しています。")
+    return RedisResultStore()

--- a/apps/api/services/zpe/settings.py
+++ b/apps/api/services/zpe/settings.py
@@ -1,21 +1,28 @@
 from __future__ import annotations
 
 from functools import lru_cache
+from pathlib import Path
 from typing import Optional
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+_ENV_FILE = Path(__file__).resolve().parents[2] / ".env"
 
 
 class ZPESettings(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="ZPE_",
-        env_file=".env",
+        env_file=str(_ENV_FILE),
         extra="ignore",
     )
 
     redis_url: str = "redis://localhost:6379/0"
     work_dir: str = "zpe_jobs"
     queue_name: str = "zpe"
+    compute_mode: str = "remote-queue"
+    result_store: str = "redis"
+    admin_token: Optional[str] = None
+    enroll_token_ttl_seconds: int = 3600
 
     pw_command: str = "pw.x"
     pw_path: Optional[str] = None

--- a/apps/api/services/zpe/worker.py
+++ b/apps/api/services/zpe/worker.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timezone
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Dict
+
+from ase.calculators.espresso import Espresso
+from ase.vibrations import Vibrations
+from rq import get_current_job
+
+from models import ZPEJobRequest
+from .cache import clean_vib_cache, sanitize_vib_cache
+from .environ import prepare_environ_files, resolve_environ_path
+from .io import format_freqs_csv, format_summary, write_freqs_csv, write_result_json, write_summary
+from .parse import (
+    ensure_mobile_indices,
+    extract_fixed_indices,
+    parse_atomic_species,
+    parse_kpoints_automatic,
+    parse_namelist,
+    parse_qe_atoms,
+)
+from .paths import resolve_pseudo_dir, resolve_work_dir
+from .qe import build_espresso_profile
+from .result_store import get_result_store
+from .settings import get_zpe_settings
+from .thermo import calc_zpe_and_s_vib, normalize_frequencies
+
+
+@contextmanager
+def _chdir(path: Path):
+    prev = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(prev)
+
+
+def _default_kpts() -> tuple[int, int, int]:
+    return (1, 1, 1)
+
+
+def run_zpe_job(payload: Dict[str, Any]) -> Dict[str, Any]:
+    settings = get_zpe_settings()
+    store = get_result_store()
+
+    job = get_current_job()
+    job_id = job.id if job else payload.get("job_id", "local")
+    store.set_status(job_id, "started")
+
+    request = ZPEJobRequest(**payload)
+    work_dir = resolve_work_dir(settings)
+    job_dir = work_dir / job_id
+    job_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        start_time = datetime.now(timezone.utc)
+        with _chdir(job_dir):
+            atoms = parse_qe_atoms(request.content)
+            fixed_indices = extract_fixed_indices(request.content)
+            mobile_indices = ensure_mobile_indices(
+                request.mobile_indices,
+                natoms=len(atoms),
+                fixed_indices=fixed_indices,
+            )
+
+            pseudos = parse_atomic_species(request.content)
+            if not pseudos:
+                raise ValueError("ATOMIC_SPECIES が見つかりません。")
+
+            kpts = parse_kpoints_automatic(request.content)
+            kpts_use = kpts[0] if kpts else _default_kpts()
+
+            control_defaults = {
+                "calculation": "scf",
+                "prefix": "ase_calc",
+                "outdir": settings.outdir_name,
+                "tprnfor": True,
+                "tstress": False,
+            }
+            system_defaults = {
+                "occupations": "smearing",
+                "smearing": "mp",
+                "degauss": 0.02,
+            }
+            electrons_defaults = {
+                "conv_thr": 1.0e-6,
+                "mixing_beta": 0.3,
+                "mixing_mode": "plain",
+                "electron_maxstep": 100,
+            }
+
+            control_from_in = parse_namelist(request.content, "control")
+            system_from_in = parse_namelist(request.content, "system")
+            electrons_from_in = parse_namelist(request.content, "electrons")
+
+            pseudo_dir = resolve_pseudo_dir(
+                request.content,
+                request.input_dir,
+                settings=settings,
+            )
+
+            control_dict = {**control_defaults, **control_from_in}
+            control_dict["pseudo_dir"] = pseudo_dir
+
+            system_dict = {**system_defaults, **system_from_in}
+            electrons_dict = {**electrons_defaults, **electrons_from_in}
+
+            input_data = {
+                "control": control_dict,
+                "system": system_dict,
+                "electrons": electrons_dict,
+            }
+
+            calc_dir = job_dir / settings.calc_dir_name
+            calc_dir.mkdir(parents=True, exist_ok=True)
+
+            if request.use_environ:
+                environ_src = resolve_environ_path(settings, request.input_dir, job_dir)
+                prepare_environ_files(
+                    settings.vib_name,
+                    len(mobile_indices),
+                    environ_src,
+                    base_dir=job_dir,
+                )
+                shutil.copy2(environ_src, calc_dir / "environ.in")
+
+            profile = build_espresso_profile(
+                pseudo_dir=pseudo_dir,
+                use_mpi=settings.use_mpi,
+                np_core=settings.np_core,
+                environ=request.use_environ,
+                settings=settings,
+            )
+
+            atoms.calc = Espresso(
+                pseudopotentials=pseudos,
+                input_data=input_data,
+                kpts=kpts_use,
+                profile=profile,
+                directory=str(calc_dir),
+            )
+
+            if request.calc_mode == "new":
+                clean_vib_cache(job_dir, settings.vib_name)
+
+            cache_info = sanitize_vib_cache(job_dir, settings.vib_name, natoms=len(atoms))
+
+            vib = Vibrations(
+                atoms,
+                indices=mobile_indices,
+                delta=settings.delta,
+                name=settings.vib_name,
+            )
+            vib.run()
+            freqs_cm = vib.get_frequencies()
+
+        zpe_ev, s_vib_jmol_k = calc_zpe_and_s_vib(
+            freqs_cm,
+            low_cut_cm=settings.low_cut_cm,
+            temperature=settings.temperature,
+        )
+
+        end_time = datetime.now(timezone.utc)
+        elapsed_seconds = (end_time - start_time).total_seconds()
+
+        qe_input_label = request.input_dir or "inline"
+        checked_files = cache_info.get("checked_files", 0)
+        deleted_files = cache_info.get("deleted_files", 0)
+        result: Dict[str, Any] = {
+            "freqs_cm": normalize_frequencies(freqs_cm),
+            "zpe_ev": zpe_ev,
+            "s_vib_jmol_k": s_vib_jmol_k,
+            "mobile_indices": mobile_indices,
+            "fixed_indices": fixed_indices,
+            "kpts": kpts_use,
+            "delta": settings.delta,
+            "low_cut_cm": settings.low_cut_cm,
+            "temperature": settings.temperature,
+            "use_environ": request.use_environ,
+            "qe_input": qe_input_label,
+            "pseudo_dir": pseudo_dir,
+            "calc_start_time": start_time.isoformat(),
+            "calc_end_time": end_time.isoformat(),
+            "elapsed_seconds": elapsed_seconds,
+            "cache_checked": int(checked_files) if isinstance(checked_files, (int, float)) else 0,
+            "cache_deleted": int(deleted_files) if isinstance(deleted_files, (int, float)) else 0,
+            "ecutwfc": system_dict.get("ecutwfc"),
+            "ecutrho": system_dict.get("ecutrho"),
+        }
+
+        summary_path = job_dir / "summary.txt"
+        freqs_path = job_dir / "freqs.csv"
+        result_path = job_dir / "result.json"
+
+        write_summary(
+            summary_path,
+            result,
+            pseudo_dir=pseudo_dir,
+            qe_input=qe_input_label,
+            new_calc=request.calc_mode == "new",
+        )
+        write_freqs_csv(freqs_path, freqs_cm)
+        write_result_json(result_path, result)
+
+        summary_text = format_summary(
+            result,
+            pseudo_dir=pseudo_dir,
+            qe_input=qe_input_label,
+            new_calc=request.calc_mode == "new",
+        )
+        freqs_csv = format_freqs_csv(freqs_cm)
+
+        store.set_result(job_id, result, summary_text=summary_text, freqs_csv=freqs_csv)
+        store.set_status(job_id, "finished")
+        return result
+    except Exception as exc:
+        store.set_status(job_id, "failed", detail=str(exc))
+        raise

--- a/apps/api/tests/test_zpe_api.py
+++ b/apps/api/tests/test_zpe_api.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import fakeredis
+from fastapi.testclient import TestClient
+
+import main
+from services.zpe import backends as zpe_backends
+from services.zpe import enroll as zpe_enroll
+from services.zpe import result_store as zpe_store
+from services.zpe.result_store import RedisResultStore
+from services.zpe.settings import ZPESettings
+
+QE_INPUT = """
+&CONTROL
+  calculation='scf'
+/
+&SYSTEM
+  ibrav=0, nat=1, ntyp=1
+/
+&ELECTRONS
+/
+ATOMIC_SPECIES
+ H 1.0079 H.pbe-rrkjus.UPF
+CELL_PARAMETERS angstrom
+  5.0 0.0 0.0
+  0.0 5.0 0.0
+  0.0 0.0 5.0
+ATOMIC_POSITIONS angstrom
+ H 0.0 0.0 0.0 1 1 1
+""".strip()
+
+
+def _patch_redis(monkeypatch):
+    fake = fakeredis.FakeRedis()
+    monkeypatch.setattr(zpe_store, "get_redis_connection", lambda: fake)
+    monkeypatch.setattr(zpe_enroll, "get_redis_connection", lambda: fake)
+    return fake
+
+
+def test_zpe_mock_api_flow(monkeypatch):
+    fake = _patch_redis(monkeypatch)
+    store = RedisResultStore(redis=fake)
+    settings = ZPESettings(compute_mode="mock", result_store="redis")
+
+    monkeypatch.setattr(zpe_backends, "get_result_store", lambda: store)
+    monkeypatch.setattr(zpe_backends, "get_zpe_settings", lambda: settings)
+
+    client = TestClient(main.app)
+    response = client.post(
+        "/calc/zpe/jobs",
+        json={
+            "content": QE_INPUT,
+            "mobile_indices": [0],
+            "use_environ": False,
+            "input_dir": None,
+            "calc_mode": "continue",
+        },
+    )
+    assert response.status_code == 200
+    job_id = response.json()["job_id"]
+
+    status = client.get(f"/calc/zpe/jobs/{job_id}")
+    assert status.status_code == 200
+    assert status.json()["status"] == "finished"
+
+    result = client.get(f"/calc/zpe/jobs/{job_id}/result")
+    assert result.status_code == 200
+    payload = result.json()["result"]
+    assert payload["zpe_ev"] >= 0.0
+    assert payload["mobile_indices"] == [0]
+
+    summary = client.get(f"/calc/zpe/jobs/{job_id}/files", params={"kind": "summary"})
+    assert summary.status_code == 200
+    assert "ZPE summary" in summary.text
+
+    freqs = client.get(f"/calc/zpe/jobs/{job_id}/files", params={"kind": "freqs"})
+    assert freqs.status_code == 200
+    assert freqs.text.startswith("frequency_cm^-1")
+
+
+def test_zpe_enroll_token_api(monkeypatch):
+    _patch_redis(monkeypatch)
+    settings = ZPESettings(admin_token="secret")
+    monkeypatch.setattr(main, "get_zpe_settings", lambda: settings)
+
+    client = TestClient(main.app)
+    response = client.post("/calc/zpe/compute/enroll-tokens", json={"ttl_seconds": 60})
+    assert response.status_code == 401
+
+    response = client.post(
+        "/calc/zpe/compute/enroll-tokens",
+        json={"ttl_seconds": 60, "label": "lab"},
+        headers={"Authorization": "Bearer secret"},
+    )
+    assert response.status_code == 200
+    token = response.json()["token"]
+
+    register = client.post(
+        "/calc/zpe/compute/servers/register",
+        json={"token": token, "name": "server-1"},
+    )
+    assert register.status_code == 200
+    assert register.json()["server_id"].startswith("compute-")

--- a/apps/api/tests/test_zpe_e2e_h2.py
+++ b/apps/api/tests/test_zpe_e2e_h2.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import math
+import os
+from pathlib import Path
+
+import fakeredis
+import pytest
+
+from services.zpe import settings as zpe_settings
+from services.zpe import worker
+from services.zpe.result_store import RedisResultStore
+
+
+QE_INPUT_TEMPLATE = """
+&CONTROL
+  calculation='scf'
+  prefix='ase_calc'
+  outdir='calc_scratch'
+/
+&SYSTEM
+  ibrav=0, nat=2, ntyp=1
+  ecutwfc=10.0, ecutrho=80.0
+  occupations='smearing'
+  smearing='mp'
+  degauss=0.02
+/
+&ELECTRONS
+  conv_thr=1.0d-4
+  electron_maxstep=30
+/
+ATOMIC_SPECIES
+ H 1.0079 {pseudo}
+CELL_PARAMETERS angstrom
+  6.0 0.0 0.0
+  0.0 6.0 0.0
+  0.0 0.0 6.0
+ATOMIC_POSITIONS angstrom
+ H 0.0 0.0 0.0 1 1 1
+ H 0.0 0.0 0.74 1 1 1
+K_POINTS gamma
+""".strip()
+
+
+@pytest.mark.e2e
+def test_zpe_e2e_h2(monkeypatch):
+    if os.environ.get("ZPE_E2E") != "1":
+        pytest.skip("Set ZPE_E2E=1 to run QE E2E test")
+
+    pw_path = os.environ.get("ZPE_PW_PATH")
+    pseudo_dir = os.environ.get("ZPE_PSEUDO_DIR")
+    pseudo_name = os.environ.get("ZPE_E2E_PSEUDO", "H.pbe-rrkjus_psl.1.0.0.UPF")
+
+    if not pw_path or not Path(pw_path).exists():
+        pytest.skip("ZPE_PW_PATH is missing or invalid")
+    if not pseudo_dir or not Path(pseudo_dir).is_dir():
+        pytest.skip("ZPE_PSEUDO_DIR is missing or invalid")
+    if not (Path(pseudo_dir) / pseudo_name).exists():
+        pytest.skip("Pseudo file not found in ZPE_PSEUDO_DIR")
+
+    monkeypatch.setenv("ZPE_PW_PATH", pw_path)
+    monkeypatch.setenv("ZPE_PSEUDO_DIR", pseudo_dir)
+    monkeypatch.setenv("ZPE_USE_MPI", "false")
+    monkeypatch.setenv("ZPE_NP_CORE", "1")
+    zpe_settings.get_zpe_settings.cache_clear()
+
+    fake = fakeredis.FakeRedis()
+    monkeypatch.setattr(worker, "get_result_store", lambda: RedisResultStore(redis=fake))
+
+    qe_input = QE_INPUT_TEMPLATE.format(pseudo=pseudo_name)
+    payload = {
+        "content": qe_input,
+        "mobile_indices": [0, 1],
+        "use_environ": False,
+        "input_dir": None,
+        "calc_mode": "new",
+        "job_id": "e2e-h2",
+    }
+
+    result = worker.run_zpe_job(payload)
+    freqs = result["freqs_cm"]
+    assert len(freqs) == 6
+    assert all(math.isfinite(freq) for freq in freqs)
+
+    max_freq = max(freqs)
+    ref_freq = 4401.0
+    tol_freq = float(os.environ.get("ZPE_E2E_FREQ_TOL_FRAC", "0.25"))
+    assert abs(max_freq - ref_freq) <= ref_freq * tol_freq
+
+    ref_zpe = 0.26
+    tol_zpe = float(os.environ.get("ZPE_E2E_ZPE_TOL_FRAC", "0.35"))
+    zpe_ev = result["zpe_ev"]
+    assert abs(zpe_ev - ref_zpe) <= ref_zpe * tol_zpe

--- a/apps/api/tests/test_zpe_e2e_molecules.py
+++ b/apps/api/tests/test_zpe_e2e_molecules.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence, cast
+from uuid import uuid4
+
+import fakeredis
+import pytest
+
+from services.zpe import settings as zpe_settings
+from services.zpe.result_store import RedisResultStore
+from services.zpe.thermo import HC_EV_CM
+from services.zpe import worker
+
+
+@dataclass(frozen=True)
+class MoleculeCase:
+    name: str
+    natoms: int
+    qe_input: str
+    targets_cm: Sequence[float]
+    pseudos: Sequence[str]
+
+
+def _ensure_env() -> tuple[str, str]:
+    if os.environ.get("ZPE_E2E") != "1":
+        pytest.skip("Set ZPE_E2E=1 to run QE E2E tests")
+
+    pw_path = os.environ.get("ZPE_PW_PATH")
+    pseudo_dir = os.environ.get("ZPE_PSEUDO_DIR")
+    if not pw_path or not Path(pw_path).exists():
+        pytest.skip("ZPE_PW_PATH is missing or invalid")
+    if not pseudo_dir or not Path(pseudo_dir).is_dir():
+        pytest.skip("ZPE_PSEUDO_DIR is missing or invalid")
+    return pw_path, pseudo_dir
+
+
+def _set_env(monkeypatch, pw_path: str, pseudo_dir: str) -> None:
+    monkeypatch.setenv("ZPE_PW_PATH", pw_path)
+    monkeypatch.setenv("ZPE_PSEUDO_DIR", pseudo_dir)
+    monkeypatch.setenv("ZPE_USE_MPI", "false")
+    monkeypatch.setenv("ZPE_NP_CORE", "1")
+    zpe_settings.get_zpe_settings.cache_clear()
+
+
+def _run_case(case: MoleculeCase, *, pseudo_dir: str) -> dict[str, object]:
+    fake = fakeredis.FakeRedis()
+    worker.get_result_store = lambda: RedisResultStore(redis=fake)
+
+    job_id = f"e2e-{case.name}-{uuid4().hex[:8]}"
+    payload = {
+        "content": case.qe_input,
+        "mobile_indices": list(range(case.natoms)),
+        "use_environ": False,
+        "input_dir": None,
+        "calc_mode": "new",
+        "job_id": job_id,
+    }
+    return worker.run_zpe_job(payload)
+
+
+def _filter_positive(freqs: Iterable[float], *, low_cut: float) -> List[float]:
+    return [freq for freq in freqs if math.isfinite(freq) and freq > low_cut]
+
+
+def _assert_targets(freqs: Sequence[float], targets: Sequence[float], tol_frac: float) -> None:
+    for target in targets:
+        closest = min(abs(freq - target) for freq in freqs)
+        assert closest <= target * tol_frac
+
+
+def _assert_zpe(result: dict[str, object], targets: Sequence[float], tol_frac: float) -> None:
+    expected = 0.5 * HC_EV_CM * float(sum(targets))
+    zpe_ev = float(cast(float, result["zpe_ev"]))
+    assert abs(zpe_ev - expected) <= expected * tol_frac
+
+
+CASES: Sequence[MoleculeCase] = [
+    MoleculeCase(
+        name="n2",
+        natoms=2,
+        qe_input=(
+            """
+&CONTROL
+  calculation='scf'
+  prefix='ase_calc'
+  outdir='calc_scratch'
+/
+&SYSTEM
+  ibrav=0, nat=2, ntyp=1
+  ecutwfc=30.0, ecutrho=240.0
+  occupations='fixed'
+/
+&ELECTRONS
+  conv_thr=1.0d-6
+  electron_maxstep=80
+/
+ATOMIC_SPECIES
+ N 14.0067 N.pbe-n-rrkjus_psl.1.0.0.UPF
+CELL_PARAMETERS angstrom
+  10.0 0.0 0.0
+  0.0 10.0 0.0
+  0.0 0.0 10.0
+ATOMIC_POSITIONS angstrom
+ N 0.0 0.0 0.0 1 1 1
+ N 0.0 0.0 1.10 1 1 1
+K_POINTS gamma
+"""
+        ).strip(),
+        targets_cm=[2330.0],
+        pseudos=["N.pbe-n-rrkjus_psl.1.0.0.UPF"],
+    ),
+    MoleculeCase(
+        name="co",
+        natoms=2,
+        qe_input=(
+            """
+&CONTROL
+  calculation='scf'
+  prefix='ase_calc'
+  outdir='calc_scratch'
+/
+&SYSTEM
+  ibrav=0, nat=2, ntyp=2
+  ecutwfc=30.0, ecutrho=240.0
+  occupations='fixed'
+/
+&ELECTRONS
+  conv_thr=1.0d-6
+  electron_maxstep=80
+/
+ATOMIC_SPECIES
+ C 12.0107 C.pbe-n-rrkjus_psl.1.0.0.UPF
+ O 15.999 O.pbe-n-rrkjus_psl.1.0.0.UPF
+CELL_PARAMETERS angstrom
+  10.0 0.0 0.0
+  0.0 10.0 0.0
+  0.0 0.0 10.0
+ATOMIC_POSITIONS angstrom
+ C 0.0 0.0 0.0 1 1 1
+ O 0.0 0.0 1.13 1 1 1
+K_POINTS gamma
+"""
+        ).strip(),
+        targets_cm=[2143.0],
+        pseudos=["C.pbe-n-rrkjus_psl.1.0.0.UPF", "O.pbe-n-rrkjus_psl.1.0.0.UPF"],
+    ),
+    MoleculeCase(
+        name="co2",
+        natoms=3,
+        qe_input=(
+            """
+&CONTROL
+  calculation='scf'
+  prefix='ase_calc'
+  outdir='calc_scratch'
+/
+&SYSTEM
+  ibrav=0, nat=3, ntyp=2
+  ecutwfc=30.0, ecutrho=240.0
+  occupations='fixed'
+/
+&ELECTRONS
+  conv_thr=1.0d-6
+  electron_maxstep=80
+/
+ATOMIC_SPECIES
+ C 12.0107 C.pbe-n-rrkjus_psl.1.0.0.UPF
+ O 15.999 O.pbe-n-rrkjus_psl.1.0.0.UPF
+CELL_PARAMETERS angstrom
+  10.0 0.0 0.0
+  0.0 10.0 0.0
+  0.0 0.0 10.0
+ATOMIC_POSITIONS angstrom
+ O 0.0 0.0 -1.16 1 1 1
+ C 0.0 0.0 0.0 1 1 1
+ O 0.0 0.0 1.16 1 1 1
+K_POINTS gamma
+"""
+        ).strip(),
+        targets_cm=[667.0, 1388.0, 2349.0],
+        pseudos=["C.pbe-n-rrkjus_psl.1.0.0.UPF", "O.pbe-n-rrkjus_psl.1.0.0.UPF"],
+    ),
+    MoleculeCase(
+        name="h2o",
+        natoms=3,
+        qe_input=(
+            """
+&CONTROL
+  calculation='scf'
+  prefix='ase_calc'
+  outdir='calc_scratch'
+/
+&SYSTEM
+  ibrav=0, nat=3, ntyp=2
+  ecutwfc=30.0, ecutrho=240.0
+  occupations='fixed'
+/
+&ELECTRONS
+  conv_thr=1.0d-6
+  electron_maxstep=80
+/
+ATOMIC_SPECIES
+ H 1.0079 H.pbe-rrkjus_psl.1.0.0.UPF
+ O 15.999 O.pbe-n-rrkjus_psl.1.0.0.UPF
+CELL_PARAMETERS angstrom
+  10.0 0.0 0.0
+  0.0 10.0 0.0
+  0.0 0.0 10.0
+ATOMIC_POSITIONS angstrom
+ O 0.0000 0.0000 0.0000 1 1 1
+ H 0.9572 0.0000 0.0000 1 1 1
+ H -0.2390 0.9270 0.0000 1 1 1
+K_POINTS gamma
+"""
+        ).strip(),
+        targets_cm=[1595.0, 3657.0, 3756.0],
+        pseudos=["H.pbe-rrkjus_psl.1.0.0.UPF", "O.pbe-n-rrkjus_psl.1.0.0.UPF"],
+    ),
+]
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("case", CASES, ids=[case.name for case in CASES])
+def test_zpe_e2e_molecules(monkeypatch, case: MoleculeCase):
+    pw_path, pseudo_dir = _ensure_env()
+    _set_env(monkeypatch, pw_path, pseudo_dir)
+
+    for pseudo in case.pseudos:
+        if not (Path(pseudo_dir) / pseudo).exists():
+            pytest.skip(f"Pseudo file not found: {pseudo}")
+
+    result = _run_case(case, pseudo_dir=pseudo_dir)
+    freqs = cast(List[float], result["freqs_cm"])
+    assert len(freqs) == 3 * case.natoms
+
+    low_cut = float(cast(float, result["low_cut_cm"]))
+    positive = _filter_positive(freqs, low_cut=low_cut)
+
+    tol_freq = float(os.environ.get("ZPE_E2E_FREQ_TOL_FRAC", "0.3"))
+    _assert_targets(positive, case.targets_cm, tol_freq)
+
+    tol_zpe = float(os.environ.get("ZPE_E2E_ZPE_TOL_FRAC", "0.5"))
+    _assert_zpe(result, case.targets_cm, tol_zpe)

--- a/apps/api/tests/test_zpe_enroll.py
+++ b/apps/api/tests/test_zpe_enroll.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import fakeredis
+import pytest
+
+from services.zpe.enroll import ComputeEnrollStore
+
+
+def test_enroll_token_roundtrip():
+    fake = fakeredis.FakeRedis()
+    store = ComputeEnrollStore(redis=fake)
+
+    token = store.create_token(ttl_seconds=60, label="lab")
+    assert token.token
+    assert token.ttl_seconds == 60
+    assert token.expires_at
+
+    registration = store.consume_token(token.token, name="server-1", meta={"host": "node"})
+    assert registration.server_id.startswith("compute-")
+    assert registration.name == "server-1"
+    assert registration.meta["host"] == "node"
+
+    with pytest.raises(KeyError):
+        store.consume_token(token.token)

--- a/apps/api/tests/test_zpe_mock_backend.py
+++ b/apps/api/tests/test_zpe_mock_backend.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import fakeredis
+
+from models import ZPEJobRequest
+from services.zpe import backends
+from services.zpe.result_store import RedisResultStore
+from services.zpe.settings import ZPESettings
+
+
+def test_mock_backend_produces_result(monkeypatch):
+    fake = fakeredis.FakeRedis()
+    store = RedisResultStore(redis=fake)
+    settings = ZPESettings(compute_mode="mock", result_store="redis")
+
+    monkeypatch.setattr(backends, "get_result_store", lambda: store)
+    monkeypatch.setattr(backends, "get_zpe_settings", lambda: settings)
+
+    qe_input = """
+&control
+/
+ATOMIC_POSITIONS angstrom
+H 0 0 0 1 1 1
+""".strip()
+
+    payload = ZPEJobRequest(
+        content=qe_input,
+        mobile_indices=[0],
+        use_environ=False,
+        input_dir=None,
+        calc_mode="continue",
+    ).model_dump()
+
+    job_id = backends.enqueue_zpe_job(payload)
+    assert job_id.startswith("mock-")
+
+    status = store.get_status(job_id)
+    assert status.status == "finished"
+
+    result = store.get_result(job_id)
+    assert result["zpe_ev"] >= 0.0
+    assert len(result["freqs_cm"]) == 3
+    assert result["mobile_indices"] == [0]

--- a/apps/api/tests/test_zpe_result_store.py
+++ b/apps/api/tests/test_zpe_result_store.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import fakeredis
+
+from services.zpe.result_store import RedisResultStore
+
+
+def test_redis_result_store_roundtrip():
+    fake = fakeredis.FakeRedis()
+    store = RedisResultStore(redis=fake)
+
+    store.set_status("job-1", "queued")
+    status = store.get_status("job-1")
+    assert status.status == "queued"
+    assert status.detail is None
+    assert status.updated_at is not None
+
+    result = {"zpe_ev": 0.1, "freqs_cm": [100.0]}
+    store.set_result("job-1", result, summary_text="summary", freqs_csv="freqs")
+    assert store.get_result("job-1") == result
+    assert store.get_file("job-1", "summary") == "summary"
+    assert store.get_file("job-1", "freqs") == "freqs"

--- a/specs/003-zpe-remote-compute/plan.md
+++ b/specs/003-zpe-remote-compute/plan.md
@@ -1,0 +1,62 @@
+# Implementation Plan: ZPE 計算サーバ分離
+
+**Branch**: `[refactor/zpe-remote-compute]` | **Date**: 2026-01-10 | **Spec**: `specs/003-zpe-remote-compute/spec.md`
+**Input**: Feature specification from `specs/003-zpe-remote-compute/spec.md`
+
+## Summary
+
+ZPE 計算を `control-plane`（API）と `compute-plane`（計算）に分離し、サービス提供側では計算が走らない構成にする。ジョブは Redis/RQ で計算サーバーに委譲し、結果は共有ストア（初期は Redis）で受け渡す。E2E/CI 向けにモック計算モードも提供する。
+
+## Technical Context
+
+- **Language/Version**: Python 3.13
+- **Primary Dependencies**: FastAPI, RQ, redis-py, pydantic-settings
+- **Result Store**: Public Redis + TLS + ACL（将来 S3 へ差し替え可能な設計）
+- **Testing**: pytest（モックバックエンド + ストアのユニットテスト）
+- **Target Platform**: API: 任意のクラウド / Compute: 計算サーバー
+- **Constraints**: API 側は `pw.x` や pseudo を持たない前提
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/003-zpe-remote-compute/
+├── spec.md
+├── plan.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```
+apps/api/
+├── services/zpe/
+│   ├── backends.py      # 計算委譲アダプタ
+│   ├── result_store.py  # 結果保存/取得
+│   └── settings.py      # compute mode など追加
+└── main.py              # /calc/zpe/* でバックエンド切替を利用
+```
+
+**Structure Decision**: 既存の `apps/api/services/zpe` にアダプタ層を追加し、API 自体は `/calc/zpe/*` を維持する。
+
+## Work Phases
+
+1. **Design/Setup**
+   - `ZPE_COMPUTE_MODE` / `ZPE_RESULT_STORE` など設定追加
+   - Public Redis + TLS + ACL 前提の構成を明示
+   - 短期登録トークン方式（将来のユーザー単位登録へ拡張）を設計
+   - 結果ストアとバックエンドのインターフェース定義
+2. **Core Implementation**
+   - `remote-queue`（RQ + Redis）バックエンド
+   - `mock` バックエンド（決定論的なダミー結果）
+   - 結果保存/取得の統一（Redis）
+3. **Verification**
+   - 共有ストア経由の結果取得テスト
+   - モックモードのE2E向け検証
+
+## Rollback Plan
+
+- 追加したバックエンド/ストア層を削除
+- `ZPE_COMPUTE_MODE` を `local` に戻す
+- `/calc/zpe/*` の挙動を従来のローカル方式に戻す

--- a/specs/003-zpe-remote-compute/tasks.md
+++ b/specs/003-zpe-remote-compute/tasks.md
@@ -1,0 +1,28 @@
+# Tasks: ZPE 計算サーバ分離
+
+**Input**: `specs/003-zpe-remote-compute/spec.md` / `specs/003-zpe-remote-compute/plan.md`
+**Tests**: pytest（バックエンド/ストアの単体テストを優先）
+
+**Format**: `[ID] [P?] [Story] Description`
+**Stories**: US1=委譲, US2=結果共有, US3=モック
+
+---
+
+## Phase 1: Setup
+
+- [x] T200 [P] [US1] ZPE 設定に `compute_mode` / `result_store` / `auth` を追加
+- [x] T201 [P] [US2] `ResultStore` インターフェースと Redis 実装を作成
+
+## Phase 2: Core Implementation
+
+- [x] T210 [P] [US1] `remote-queue` バックエンド（RQ への enqueue + meta 更新）
+- [x] T211 [P] [US2] 結果取得 API が Redis ストア経由で返すように変更
+- [x] T212 [US3] `mock` バックエンド（決定論的ダミー結果）
+- [x] T213 [US1/2] エラーハンドリング（計算サーバー/ストア障害の明確化）
+- [x] T214 [US1] 計算サーバ登録トークン（MVP: 管理者発行、将来拡張前提）
+
+## Phase 3: Tests & Validation
+
+- [x] T220 [P] [US1/2] Redis ストアの単体テスト
+- [x] T221 [US3] モックモードのAPIテスト
+- [x] T222 [P] [US1/2/3] pytest / mypy / ruff 実行


### PR DESCRIPTION
## Summary
- Split ZPE compute into control-plane enqueue + compute-plane worker using Redis/RQ.
- Store results in Redis and expose status/result/files APIs.
- Add compute server enroll tokens (admin-only MVP) and E2E tests (H2 + small molecules).

## Testing
- uv run pytest tests/test_zpe_result_store.py tests/test_zpe_mock_backend.py tests/test_zpe_api.py
- uv run pytest tests/test_zpe_e2e_h2.py (QE E2E, `ZPE_E2E=1`)
- uv run pytest tests/test_zpe_e2e_molecules.py -k n2/co/co2/h2o (QE E2E, `ZPE_E2E=1`)
- uv run ruff check .
- uv run mypy .

## Notes
- E2E molecules are heavy; run with `-k` to avoid long runtimes.

Closes #25
Closes #26
Closes #27
Closes #28
Relates to #29


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

**New Features**
- Added ZPE calculation API endpoints for submitting jobs, checking status, and retrieving results
- Compute server enrollment system with token-based registration for distributed computation
- Downloadable job output files (summaries and frequency data)

**Tests**
- Added comprehensive test coverage for ZPE functionality, including end-to-end validation scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->