### PR TITLE
revert: remove /supercell/build implementation

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import secrets
-from typing import Any, Literal
+from typing import Literal
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -22,9 +22,6 @@ from models import (
     ParseResponse,
     StructureCreateRequest,
     StructureCreateResponse,
-    SupercellBuildMeta,
-    SupercellBuildRequest,
-    SupercellBuildResponse,
     SupercellRequest,
     SupercellResponse,
     TiledSupercellRequest,
@@ -42,18 +39,9 @@ from models import (
 )
 from services.export import export_qe_in
 from services.lattice import params_to_vectors, vectors_to_params
-from services.parse import parse_qe_in, structure_from_ase
-from services.structures import (
-    create_structure_from_qe,
-    get_structure_bcif,
-    get_structure_entry,
-    register_structure_atoms,
-)
-from services.supercell import (
-    build_supercell_from_grid,
-    generate_supercell,
-    generate_tiled_supercell,
-)
+from services.parse import parse_qe_in
+from services.structures import create_structure_from_qe, get_structure_bcif
+from services.supercell import generate_supercell, generate_tiled_supercell
 from services.transplant import transplant_delta
 from services.zpe import (
     ensure_mobile_indices,
@@ -74,27 +62,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-
-def _cell_has_lattice(cell: Any) -> bool:
-    try:
-        lengths = cell.lengths()
-    except AttributeError:
-        return False
-    return any(length > 1.0e-8 for length in lengths)
-
-
-def _cells_match(cell_a: Any, cell_b: Any, *, tol: float = 1.0e-6) -> bool:
-    try:
-        arr_a = cell_a.array
-        arr_b = cell_b.array
-    except AttributeError:
-        return False
-    for row_a, row_b in zip(arr_a, arr_b):
-        for value_a, value_b in zip(row_a, row_b):
-            if abs(float(value_a) - float(value_b)) > tol:
-                return False
-    return True
 
 
 @app.exception_handler(ValueError)
@@ -229,81 +196,6 @@ def supercell_tiled(request: TiledSupercellRequest) -> SupercellResponse:
         overlap_tolerance=request.overlapTolerance,
     )
     return SupercellResponse(structure=structure, meta=meta)
-
-
-@app.post("/supercell/build", response_model=SupercellBuildResponse)
-def supercell_build(request: SupercellBuildRequest) -> SupercellBuildResponse:
-    try:
-        base_entry = get_structure_entry(request.baseStructureId)
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail="Structure not found") from exc
-
-    base_atoms = base_entry.atoms
-    base_cell = base_atoms.get_cell()
-    if not _cell_has_lattice(base_cell):
-        raise HTTPException(status_code=400, detail="base structure has no lattice")
-
-    tiles: dict[str, Any] = {}
-    structure_ids_used: list[str] = []
-    seen: set[str] = set()
-    for row in request.grid.tiles:
-        for structure_id in row:
-            if structure_id not in seen:
-                seen.add(structure_id)
-                structure_ids_used.append(structure_id)
-            if structure_id in tiles:
-                continue
-            try:
-                entry = get_structure_entry(structure_id)
-            except KeyError as exc:
-                raise HTTPException(
-                    status_code=404, detail="Structure not found"
-                ) from exc
-            tiles[structure_id] = entry.atoms
-
-    options = request.options
-    if options and options.validateLattice != "none":
-        for structure_id, atoms in tiles.items():
-            if structure_id == request.baseStructureId:
-                continue
-            cell = atoms.get_cell()
-            lattice_ok = _cell_has_lattice(cell) and _cells_match(base_cell, cell)
-            if lattice_ok:
-                continue
-            if options.validateLattice == "error":
-                raise HTTPException(status_code=400, detail="lattice mismatch")
-            logger.warning(
-                "supercell.build lattice mismatch: %s vs base %s",
-                structure_id,
-                request.baseStructureId,
-            )
-
-    check_overlap = bool(options.checkOverlap) if options else False
-    overlap_tolerance = options.overlapTolerance if options else None
-    atoms_out, overlap_count = build_supercell_from_grid(
-        base_atoms,
-        request.grid,
-        tiles,
-        check_overlap=check_overlap,
-        overlap_tolerance=overlap_tolerance,
-    )
-
-    structure_id = register_structure_atoms(atoms_out, source="supercell-build")
-    include_structure = bool(request.output.includeStructure) if request.output else False
-    structure = structure_from_ase(atoms_out) if include_structure else None
-    meta = SupercellBuildMeta(
-        rows=request.grid.rows,
-        cols=request.grid.cols,
-        tileCount=request.grid.rows * request.grid.cols,
-        overlapCount=overlap_count if check_overlap else None,
-        baseStructureId=request.baseStructureId,
-        structureIdsUsed=structure_ids_used,
-    )
-    return SupercellBuildResponse(
-        structureId=structure_id,
-        structure=structure,
-        meta=meta,
-    )
 
 
 @app.post("/lattice/vectors-to-params", response_model=LatticeConvertResponse)

--- a/apps/api/models.py
+++ b/apps/api/models.py
@@ -166,6 +166,7 @@ class SupercellBuildOptions(BaseModel):
 
 
 class SupercellBuildOutput(BaseModel):
+    register: bool = True
     includeStructure: bool = False
 
 

--- a/apps/api/services/structures.py
+++ b/apps/api/services/structures.py
@@ -84,15 +84,3 @@ def get_structure_bcif(
     if not entry:
         raise KeyError(structure_id)
     return cif_to_bcif(entry.cif, lossy=lossy, precision=precision)
-
-
-def get_structure_entry(structure_id: str) -> StoredStructure:
-    entry = _STORE.get(structure_id)
-    if not entry:
-        raise KeyError(structure_id)
-    return entry
-
-
-def register_structure_atoms(atoms: ASEAtoms, source: str) -> str:
-    cif = atoms_to_cif(atoms)
-    return _STORE.create(atoms=atoms, source=source, cif=cif)

--- a/apps/api/tests/test_supercell.py
+++ b/apps/api/tests/test_supercell.py
@@ -1,13 +1,7 @@
 from __future__ import annotations
 
-from ase import Atoms as ASEAtoms
-
-from services.supercell import (
-    build_supercell_from_grid,
-    generate_supercell,
-    generate_tiled_supercell,
-)
-from models import Atom, Lattice, Structure, SupercellGrid, SupercellGridAxis, Vector3
+from services.supercell import generate_supercell, generate_tiled_supercell
+from models import Atom, Lattice, Structure, Vector3
 
 
 def _make_lattice(
@@ -55,65 +49,3 @@ def test_generate_tiled_supercell_overlap_count():
     assert meta.na == 2
     assert meta.nb == 1
     assert meta.overlapCount == 1
-
-
-def test_build_supercell_from_grid_default_axis():
-    base_atoms = ASEAtoms(
-        symbols=["H"],
-        positions=[(0.0, 0.0, 0.0)],
-        cell=[(1.0, 0.0, 0.0), (0.0, 2.0, 0.0), (0.0, 0.0, 3.0)],
-        pbc=True,
-    )
-    tile_a = ASEAtoms(
-        symbols=["H"],
-        positions=[(0.0, 0.0, 0.0)],
-        cell=base_atoms.get_cell(),
-        pbc=True,
-    )
-    tile_b = ASEAtoms(
-        symbols=["He"],
-        positions=[(0.5, 0.0, 0.0)],
-        cell=base_atoms.get_cell(),
-        pbc=True,
-    )
-
-    grid = SupercellGrid(
-        rows=2,
-        cols=2,
-        tiles=[["a", "b"], ["a", "b"]],
-    )
-    atoms_out, overlap_count = build_supercell_from_grid(
-        base_atoms,
-        grid,
-        {"a": tile_a, "b": tile_b},
-    )
-
-    assert overlap_count == 0
-    assert atoms_out.get_cell()[0][0] == 2.0
-    assert atoms_out.get_cell()[1][1] == 4.0
-    positions = atoms_out.get_positions()
-    assert positions[0][0] == 0.0
-    assert positions[1][0] == 1.5
-    assert positions[2][1] == 2.0
-
-
-def test_build_supercell_from_grid_axis_swap():
-    base_atoms = ASEAtoms(
-        symbols=["H"],
-        positions=[(0.0, 0.0, 0.0)],
-        cell=[(1.0, 0.0, 0.0), (0.0, 2.0, 0.0), (0.0, 0.0, 3.0)],
-        pbc=True,
-    )
-    grid = SupercellGrid(
-        rows=3,
-        cols=2,
-        tiles=[["a", "a"], ["a", "a"], ["a", "a"]],
-        axis=SupercellGridAxis(row="a", col="b"),
-    )
-    atoms_out, _ = build_supercell_from_grid(
-        base_atoms,
-        grid,
-        {"a": base_atoms},
-    )
-    assert atoms_out.get_cell()[0][0] == 3.0
-    assert atoms_out.get_cell()[1][1] == 4.0

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -105,6 +105,7 @@ export type SupercellBuildOptions = {
 }
 
 export type SupercellBuildOutput = {
+  register?: boolean
   includeStructure?: boolean
 }
 

--- a/specs/001-chem-model-webapp/contracts/supercell-build-v2.md
+++ b/specs/001-chem-model-webapp/contracts/supercell-build-v2.md
@@ -77,6 +77,7 @@ Request:
     "validateLattice": "none"
   },
   "output": {
+    "register": true,
     "includeStructure": false
   }
 }
@@ -135,4 +136,3 @@ Missing base lattice (400):
 - tiles must be rectangular and match rows/cols.
 - structureId references the backend StructureRegistry (ASE Atoms).
 - When output.includeStructure=true, the response includes the Structure payload.
-- /supercell/build always registers the output structure and returns structureId.


### PR DESCRIPTION
## Summary\n- revert PR #50 which added /supercell/build implementation and related helpers/tests\n- restore previous state so contract-only change can be handled separately\n\n## Testing\n- not run (revert only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the `/supercell/build` API endpoint and associated build operations.
  * Removed structure retrieval and atoms registration capabilities from services.

* **Updates**
  * Added optional `register` field to supercell build output configuration.

* **Refactor**
  * Consolidated API imports; removed legacy internal utility functions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->