### PR TITLE
chore: remove supercell build register flag

### DIFF
--- a/apps/api/models.py
+++ b/apps/api/models.py
@@ -166,7 +166,6 @@ class SupercellBuildOptions(BaseModel):
 
 
 class SupercellBuildOutput(BaseModel):
-    register: bool = True
     includeStructure: bool = False
 
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -105,7 +105,6 @@ export type SupercellBuildOptions = {
 }
 
 export type SupercellBuildOutput = {
-  register?: boolean
   includeStructure?: boolean
 }
 

--- a/specs/001-chem-model-webapp/contracts/supercell-build-v2.md
+++ b/specs/001-chem-model-webapp/contracts/supercell-build-v2.md
@@ -77,7 +77,6 @@ Request:
     "validateLattice": "none"
   },
   "output": {
-    "register": true,
     "includeStructure": false
   }
 }
@@ -136,3 +135,4 @@ Missing base lattice (400):
 - tiles must be rectangular and match rows/cols.
 - structureId references the backend StructureRegistry (ASE Atoms).
 - When output.includeStructure=true, the response includes the Structure payload.
+- /supercell/build always registers the output structure and returns structureId.


### PR DESCRIPTION
## Summary\n- remove output.register from supercell build output\n- document that /supercell/build always registers and returns structureId\n\n## Testing\n- not run (contract/types only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Simplified the supercell build output structure. The system now automatically registers all output structures and returns a structureId with each build operation. The register configuration option has been removed to streamline the API contract.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->