### PR TITLE
Enable bcif conversion in Cloud Run

### DIFF
--- a/apps/api/.dockerignore
+++ b/apps/api/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__
+*.pyc
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.venv
+.env
+tests

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.13-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends nodejs npm \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install --no-audit --no-fund --prefix /opt/molstar molstar@5.5.0
+ENV MOLSTAR_CIF2BCIF_PATH=/opt/molstar/node_modules/molstar/lib/commonjs/cli/cif2bcif/index.js \
+    NODE_BIN=node
+
+RUN pip install --no-cache-dir uv
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev
+
+COPY . .
+
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["uv", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
## Summary\n- install Node.js and molstar in the API image\n- set MOLSTAR_CIF2BCIF_PATH and NODE_BIN for cif2bcif\n\n## Testing\n- Not run locally (deployed to Cloud Run)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker container configuration for the API service to optimize image build and runtime performance.
  * Added Docker ignore patterns to exclude unnecessary files from the build context.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->