### PR TITLE
Add mock execution mode for ZPE worker

### DIFF
--- a/apps/api/services/zpe/settings.py
+++ b/apps/api/services/zpe/settings.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from functools import lru_cache
 import os
 from pathlib import Path
-from typing import Any, Optional, cast
+from typing import Any, Literal, Optional, cast
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -32,7 +32,7 @@ class ZPESettings(BaseSettings):
     queue_name: str = "zpe"
     compute_mode: str = "remote-queue"
     result_store: str = "redis"
-    worker_mode: str = "qe"
+    worker_mode: Literal["qe", "mock"] = "qe"
     admin_token: Optional[str] = None
     enroll_token_ttl_seconds: int = 3600
 


### PR DESCRIPTION
## Summary
- add ZPE_WORKER_MODE setting (default: qe)
- allow worker to run a deterministic mock job when ZPE_WORKER_MODE=mock

## Testing
- not run (logic change only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to select the worker mode (keeps the standard mode by default).
  * Added a mock mode that simulates job execution and returns realistic-looking results for testing, quicker feedback, and easier validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->