### PR TITLE
test: add HTTP worker integration tests

### DIFF
--- a/apps/api/tests/test_zpe_http_worker_integration.py
+++ b/apps/api/tests/test_zpe_http_worker_integration.py
@@ -99,10 +99,9 @@ def test_http_worker_success(monkeypatch, tmp_path):
     try:
         lease = http_worker._lease_job(base_url, handler_cls.token, timeout=5)
         assert lease is not None
-
-            artifacts = zpe_worker.compute_zpe_artifacts(lease["payload"], job_id=lease["job_id"])
-            http_worker._submit_result(
-                base_url,
+        artifacts = zpe_worker.compute_zpe_artifacts(lease["payload"], job_id=lease["job_id"])
+        http_worker._submit_result(
+            base_url,
             handler_cls.token,
             lease["job_id"],
             lease["lease_id"],


### PR DESCRIPTION
Add integration tests covering HTTP worker lease/result/failed flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration tests for the HTTP worker using a local mock server with Bearer authentication.
  * Tests cover job lease behavior, successful result submission, and failure submission, verifying payloads and server-side lifecycle.
  * Server lifecycle is managed per test and exercises real HTTP interactions for end-to-end validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->