### PR TITLE
fix: use relative pnpm store dir

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-store-dir=/home/grace/projects/chem-model-edit/.pnpm-store
+store-dir=.pnpm-store


### PR DESCRIPTION
- change pnpm store-dir to a relative path to avoid permission errors in Cloudflare Pages builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pnpm package store directory configuration to use a relative path for improved portability across development environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->