### PR TITLE
fix: lazy-load editor v2 on client

### DIFF
--- a/apps/web/src/routes/editor-v2.tsx
+++ b/apps/web/src/routes/editor-v2.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy } from 'react'
+import { Suspense, lazy, useEffect, useState } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 
 const EditorV2Page = lazy(() => import('@/features/editor-v2/EditorV2Page'))
@@ -8,18 +8,21 @@ export const Route = createFileRoute('/editor-v2')({
 })
 
 function EditorV2Route() {
-  if (typeof document === 'undefined') {
-    return null
-  }
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  const fallback = (
+    <div className="flex min-h-[40vh] items-center justify-center text-sm text-slate-500">
+      Loading editor...
+    </div>
+  )
+
   return (
-    <Suspense
-      fallback={
-        <div className="flex min-h-[40vh] items-center justify-center text-sm text-slate-500">
-          Loading editor...
-        </div>
-      }
-    >
-      <EditorV2Page />
+    <Suspense fallback={fallback}>
+      {mounted ? <EditorV2Page /> : fallback}
     </Suspense>
   )
 }


### PR DESCRIPTION
## Summary\n- lazy-load the editor-v2 route with a client-only guard\n\n## Testing\n- not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the editor's loading behavior to enhance performance and provide visual feedback while content loads.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->