### PR TITLE
Add ZPE ops flags and structured logging

### DIFF
--- a/apps/api/.env.control.example
+++ b/apps/api/.env.control.example
@@ -7,3 +7,6 @@ ZPE_RESULT_STORE=redis
 ZPE_ADMIN_TOKEN=change-me
 # Optional: enroll token TTL in seconds
 ZPE_ENROLL_TOKEN_TTL_SECONDS=3600
+# Optional: ops flags (default true)
+# ZPE_SUBMISSION_ENABLED=true
+# ZPE_DEQUEUE_ENABLED=true

--- a/apps/api/models.py
+++ b/apps/api/models.py
@@ -337,6 +337,7 @@ class ZPEComputeLeaseResponse(BaseModel):
     payload: Dict[str, Any]
     lease_id: str
     lease_ttl_seconds: int
+    meta: Dict[str, Any] = Field(default_factory=dict)
 
 
 class ZPEComputeResultRequest(BaseModel):
@@ -363,6 +364,16 @@ class ZPEComputeFailedResponse(BaseModel):
     ok: bool = True
     requeued: bool
     retry_count: int
+
+
+class ZPEOpsFlagsRequest(BaseModel):
+    submission_enabled: Optional[bool] = None
+    dequeue_enabled: Optional[bool] = None
+
+
+class ZPEOpsFlagsResponse(BaseModel):
+    submission_enabled: bool
+    dequeue_enabled: bool
 
 
 class AuthRegisterRequest(BaseModel):

--- a/apps/api/services/zpe/job_meta.py
+++ b/apps/api/services/zpe/job_meta.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional, cast
+
+from redis import Redis
+
+from .queue import get_redis_connection
+from .settings import get_zpe_settings
+
+
+_META_PREFIX = "zpe:job:meta:"
+
+
+class JobMetaStore:
+    def __init__(self, redis: Optional[Redis] = None) -> None:
+        self.redis = redis or get_redis_connection()
+
+    def set_meta(self, job_id: str, meta: Dict[str, Any]) -> None:
+        settings = get_zpe_settings()
+        key = f"{_META_PREFIX}{job_id}"
+        payload = json.dumps(meta, ensure_ascii=True)
+        ok = self.redis.setex(key, settings.result_ttl_seconds, payload)
+        if not ok:
+            raise RuntimeError("failed to set job meta")
+
+    def get_meta(self, job_id: str) -> Dict[str, Any]:
+        raw = cast(Optional[bytes], self.redis.get(f"{_META_PREFIX}{job_id}"))
+        if not raw:
+            return {}
+        try:
+            return cast(Dict[str, Any], json.loads(raw))
+        except json.JSONDecodeError:
+            return {}
+
+
+def get_job_meta_store() -> JobMetaStore:
+    return JobMetaStore()

--- a/apps/api/services/zpe/ops_flags.py
+++ b/apps/api/services/zpe/ops_flags.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from redis import Redis
+
+from .queue import get_redis_connection
+from .settings import get_zpe_settings
+
+
+_SUBMISSION_KEY = "zpe:ops:submission_enabled"
+_DEQUEUE_KEY = "zpe:ops:dequeue_enabled"
+
+
+def _parse_bool(raw: bytes | str | None, default: bool) -> bool:
+    if raw is None:
+        return default
+    if isinstance(raw, bytes):
+        value = raw.decode("utf-8").strip().lower()
+    else:
+        value = str(raw).strip().lower()
+    if value in {"1", "true", "yes", "on"}:
+        return True
+    if value in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+@dataclass(frozen=True)
+class OpsFlags:
+    submission_enabled: bool
+    dequeue_enabled: bool
+
+
+def get_ops_flags(*, redis: Optional[Redis] = None) -> OpsFlags:
+    settings = get_zpe_settings()
+    redis = redis or get_redis_connection()
+    submission_enabled = _parse_bool(
+        redis.get(_SUBMISSION_KEY), settings.submission_enabled
+    )
+    dequeue_enabled = _parse_bool(
+        redis.get(_DEQUEUE_KEY), settings.dequeue_enabled
+    )
+    return OpsFlags(
+        submission_enabled=submission_enabled,
+        dequeue_enabled=dequeue_enabled,
+    )
+
+
+def set_ops_flags(
+    *,
+    submission_enabled: Optional[bool] = None,
+    dequeue_enabled: Optional[bool] = None,
+    redis: Optional[Redis] = None,
+) -> OpsFlags:
+    redis = redis or get_redis_connection()
+    if submission_enabled is not None:
+        redis.set(_SUBMISSION_KEY, "1" if submission_enabled else "0")
+    if dequeue_enabled is not None:
+        redis.set(_DEQUEUE_KEY, "1" if dequeue_enabled else "0")
+    return get_ops_flags(redis=redis)

--- a/apps/api/services/zpe/settings.py
+++ b/apps/api/services/zpe/settings.py
@@ -36,6 +36,8 @@ class ZPESettings(BaseSettings):
     admin_token: Optional[str] = None
     enroll_token_ttl_seconds: int = 3600
     worker_token_ttl_seconds: int = 604800
+    submission_enabled: bool = True
+    dequeue_enabled: bool = True
 
     pw_command: str = "pw.x"
     pw_path: Optional[str] = None

--- a/apps/api/services/zpe/structured_log.py
+++ b/apps/api/services/zpe/structured_log.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def new_request_id() -> str:
+    return uuid4().hex
+
+
+def log_event(
+    logger: logging.Logger,
+    *,
+    event: str,
+    level: int = logging.INFO,
+    **fields: Any,
+) -> None:
+    payload = {"ts": _now_iso(), "event": event, **fields}
+    logger.log(
+        level,
+        json.dumps(payload, ensure_ascii=True, separators=(",", ":")),
+    )

--- a/docs/zpe-worker-setup.ja.md
+++ b/docs/zpe-worker-setup.ja.md
@@ -105,6 +105,41 @@ HTTP ワーカーの場合:
 ZPE_ENV_FILE=apps/api/.env.compute ./scripts/run-zpe-worker.sh
 ```
 
+## 運用ガードレール（ロールバック）
+
+**新規受付の停止** と **worker dequeue の停止** を admin API で切り替えできます。
+停止しても **進行中ジョブは継続** し、キューからの新規取得だけが抑制されます。
+
+状態確認:
+```bash
+curl -H "Authorization: Bearer $ZPE_ADMIN_TOKEN" \
+  http://localhost:8000/calc/zpe/admin/ops
+```
+
+新規受付を停止:
+```bash
+curl -X POST http://localhost:8000/calc/zpe/admin/ops \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ZPE_ADMIN_TOKEN" \
+  -d '{"submission_enabled": false}'
+```
+
+worker dequeue を停止:
+```bash
+curl -X POST http://localhost:8000/calc/zpe/admin/ops \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ZPE_ADMIN_TOKEN" \
+  -d '{"dequeue_enabled": false}'
+```
+
+再開:
+```bash
+curl -X POST http://localhost:8000/calc/zpe/admin/ops \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ZPE_ADMIN_TOKEN" \
+  -d '{"submission_enabled": true, "dequeue_enabled": true}'
+```
+
 `just` を使う場合:
 ```bash
 just zpe-worker


### PR DESCRIPTION
## Summary
- add structured JSON logging with request_id propagation across control/compute
- add ops flags and admin endpoints to pause submissions/dequeue
- update docs/env examples and add coverage for new behavior

## Testing
- uv run pytest tests/test_zpe_api.py tests/test_zpe_lease_api.py

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added admin API endpoints to pause/resume ZPE job submissions and worker dequeue operations independently without interrupting active jobs
  * Implemented request ID tracking and structured logging for improved observability and request correlation
  * Added job metadata tracking and persistence for audit trails

* **Documentation**
  * Added operational guardrails guide covering admin API controls and management procedures

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->