### PR TITLE
refactor(api): remove worker camelCase lease fallback

### DIFF
--- a/apps/api/services/zpe/http_worker.py
+++ b/apps/api/services/zpe/http_worker.py
@@ -175,13 +175,12 @@ def run_http_worker() -> None:
             continue
 
         backoff = poll_interval
-        # TODO(api-contract): remove camelCase fallback after all workers migrate.
-        job_id = lease.get("job_id") or lease.get("jobId")
+        job_id = lease.get("job_id")
         payload = lease.get("payload")
-        lease_id = lease.get("lease_id") or lease.get("leaseId")
+        lease_id = lease.get("lease_id")
         meta = lease.get("meta") or {}
-        request_id = meta.get("request_id") or meta.get("requestId")
-        user_id = meta.get("user_id") or meta.get("userId")
+        request_id = meta.get("request_id")
+        user_id = meta.get("user_id")
         if not job_id or not payload or not lease_id:
             log_event(
                 logger,


### PR DESCRIPTION
## What
- Remove temporary camelCase fallback when parsing leased job payloads in remote HTTP worker
- Keep snake_case as the only accepted wire shape for lease/meta fields

## Why
- Active workers are already on the new contract
- This completes the migration cleanup and removes legacy compatibility code

## Validation
- uv run --project apps/api pytest apps/api/tests/test_zpe_http_worker_integration.py apps/api/tests/test_zpe_lease_api.py
- uv run --project apps/api ruff check apps/api/services/zpe/http_worker.py
