### PR TITLE
refactor(web): switch transfer preview to API-hosted CIF view

### DIFF
--- a/apps/web/src/features/editor-v2/components/ToolPanel.tsx
+++ b/apps/web/src/features/editor-v2/components/ToolPanel.tsx
@@ -41,18 +41,17 @@ import {
 import { Switch } from '@/components/ui/switch'
 import {
   createEnrollToken,
+  createStructureFromQe,
   createZpeJob,
   deltaTransplant,
   downloadZpeFile,
   exportQeInput,
-  exportStructureCif,
   fetchQueueTargets,
   fetchZpeResult,
   fetchZpeStatus,
   getStructure,
   loginAccount,
   logoutAccount,
-  parseQeInput,
   parseZpeInput,
   registerAccount,
   selectQueueTarget,
@@ -1532,16 +1531,6 @@ function TransferToolPanel({
   }, [sourceId])
 
   useEffect(() => {
-    if (!transferSummary?.cifUrl.startsWith('blob:')) {
-      return
-    }
-    const url = transferSummary.cifUrl
-    return () => {
-      URL.revokeObjectURL(url)
-    }
-  }, [transferSummary?.cifUrl])
-
-  useEffect(() => {
     setViewerError(null)
   }, [transferSummary?.cifUrl])
 
@@ -1644,20 +1633,16 @@ function TransferToolPanel({
         if (applyTokenRef.current !== token) {
           return
         }
-        const nextStructure = await parseQeInput(content)
+        const {
+          structure: nextStructure,
+          structure_id: structureId,
+        } = await createStructureFromQe(content)
         if (applyTokenRef.current !== token) {
           return
         }
-        const previewCif = await exportStructureCif(nextStructure)
-        if (applyTokenRef.current !== token) {
-          return
-        }
-        const cifBlobUrl = URL.createObjectURL(
-          new Blob([previewCif], { type: 'chemical/x-cif' }),
-        )
         setTransferSummary({
           structure: nextStructure,
-          cifUrl: cifBlobUrl,
+          cifUrl: structureViewUrl(structureId, { format: 'cif' }),
           sourceAtoms,
           targetAtoms,
           transferredAtoms: null,
@@ -1688,16 +1673,16 @@ function TransferToolPanel({
       if (applyTokenRef.current !== token) {
         return
       }
-      const previewCif = await exportStructureCif(nextStructure)
+      const {
+        structure: previewStructure,
+        structure_id: structureId,
+      } = await createStructureFromQe(content)
       if (applyTokenRef.current !== token) {
         return
       }
-      const cifBlobUrl = URL.createObjectURL(
-        new Blob([previewCif], { type: 'chemical/x-cif' }),
-      )
       setTransferSummary({
-        structure: nextStructure,
-        cifUrl: cifBlobUrl,
+        structure: previewStructure,
+        cifUrl: structureViewUrl(structureId, { format: 'cif' }),
         sourceAtoms,
         targetAtoms,
         transferredAtoms,


### PR DESCRIPTION
## Summary
- update transfer preview in `ToolPanel` to use `createStructureFromQe` and server-backed CIF URLs
- remove client-side temporary CIF blob generation path in this panel
- align preview flow with API-managed structure lifecycle

## Testing
- attempted: `pnpm -C apps/web typecheck`
- result: failed in local worktree because `node_modules` is missing (`tsc: not found`)
