### PR TITLE
chore(git): add merge-and-clean workflow scripts

### DIFF
--- a/docs/process/merge-and-cleanup.md
+++ b/docs/process/merge-and-cleanup.md
@@ -1,0 +1,25 @@
+# Merge And Cleanup Workflow
+
+Use this flow to avoid branch deletion failures when a branch is still attached to a worktree.
+
+## Rules
+
+- Run PR merge from the `main` worktree only.
+- Do not use `--delete-branch` in `gh pr merge`.
+- Cleanup local worktree and branch after merge in a separate step.
+
+## Commands
+
+```bash
+# 1) Merge the PR from main worktree
+scripts/git/merge_pr.sh <pr-number-or-url>
+
+# 2) Cleanup worktree and local branch
+scripts/git/cleanup_worktree.sh .worktrees/<name> <branch>
+```
+
+## Dry-run
+
+```bash
+scripts/git/cleanup_worktree.sh --dry-run .worktrees/<name> <branch>
+```

--- a/scripts/git/cleanup_worktree.sh
+++ b/scripts/git/cleanup_worktree.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dry_run=0
+if [[ "${1:-}" == "--dry-run" ]]; then
+  dry_run=1
+  shift
+fi
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 [--dry-run] <worktree-path> <branch>" >&2
+  exit 1
+fi
+
+worktree_path="$1"
+branch="$2"
+
+run() {
+  if [[ $dry_run -eq 1 ]]; then
+    echo "[dry-run] $*"
+  else
+    "$@"
+  fi
+}
+
+echo "Cleaning worktree and branch"
+run git worktree remove "$worktree_path"
+run git worktree prune
+run git branch -d "$branch"
+echo "Cleanup complete: $worktree_path / $branch"

--- a/scripts/git/merge_pr.sh
+++ b/scripts/git/merge_pr.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <pr-number-or-url>" >&2
+  exit 1
+fi
+
+pr_ref="$1"
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [[ "$current_branch" != "main" ]]; then
+  echo "error: run merge_pr.sh from main worktree only (current: $current_branch)" >&2
+  echo "hint: switch to your main worktree and run again" >&2
+  exit 1
+fi
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "error: working tree is not clean. commit/stash before merging." >&2
+  exit 1
+fi
+
+echo "Merging PR with merge commit: $pr_ref"
+gh pr merge "$pr_ref" --merge
+echo "Merge complete."
+echo "Next: run scripts/git/cleanup_worktree.sh <worktree-path> <branch>"


### PR DESCRIPTION
## Summary
- add merge and cleanup scripts for worktree-safe post-merge flow
- enforce merge from main worktree and separate local cleanup step
- document the workflow under docs/process

## CodeRabbit
Optional (process-only change).