### PR TITLE
chore(gh): add safe issue/pr body templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/child-task.yml
+++ b/.github/ISSUE_TEMPLATE/child-task.yml
@@ -1,0 +1,36 @@
+name: Child Task
+description: Scoped implementation task under an epic
+title: "<area>: "
+labels:
+  - task
+body:
+  - type: input
+    id: parent
+    attributes:
+      label: Parent Epic
+      description: Parent issue number (e.g. #123)
+      placeholder: "#123"
+    validations:
+      required: true
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: What this issue must deliver.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      value: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Other issues/PRs this task depends on.
+      placeholder: "#124, #125"

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,35 @@
+name: Epic
+description: Parent issue for cross-PR delivery tracking
+title: "Epic: "
+labels:
+  - epic
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What business or technical goal this epic delivers.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: In-scope / out-of-scope items.
+    validations:
+      required: true
+  - type: textarea
+    id: child_issues
+    attributes:
+      label: Child Issues
+      description: Track with Markdown task list and issue links.
+      value: |
+        - [ ] #<child-1>
+        - [ ] #<child-2>
+  - type: textarea
+    id: dod
+    attributes:
+      label: Definition of Done
+      description: Concrete completion criteria for this epic.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## Summary
+- 
+
+## Linked Issues
+- 
+
+## Changes
+- 
+
+## Validation
+- [ ] Local checks passed
+- [ ] Added/updated tests where needed
+
+## Temporary Behavior (if any)
+- N/A
+
+## Final Behavior
+- 
+
+## Follow-up Issue/PR (if any)
+- N/A
+
+## CodeRabbit Policy
+- [ ] Required
+- [ ] Optional (process/docs-only change)

--- a/docs/process/gh-template-workflow.md
+++ b/docs/process/gh-template-workflow.md
@@ -1,0 +1,20 @@
+# GitHub Template Workflow
+
+Use body files instead of inline shell strings for issue/PR creation to avoid shell expansion bugs.
+
+## Create Issue
+
+```bash
+scripts/gh/create_issue_from_template.sh "Title" /tmp/issue_body.md task
+```
+
+## Create PR
+
+```bash
+scripts/gh/create_pr_from_template.sh main <head-branch> "PR title" /tmp/pr_body.md --draft
+```
+
+## Notes
+
+- Keep public issue/PR text in English.
+- Prefer markdown files committed in `specs/` or `/tmp/*.md` when drafting bodies.

--- a/scripts/gh/create_issue_from_template.sh
+++ b/scripts/gh/create_issue_from_template.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <title> <body-file> [label ...]" >&2
+  exit 1
+fi
+
+title="$1"
+body_file="$2"
+shift 2
+
+if [[ ! -f "$body_file" ]]; then
+  echo "error: body file not found: $body_file" >&2
+  exit 1
+fi
+
+args=(issue create --title "$title" --body-file "$body_file")
+for label in "$@"; do
+  args+=(--label "$label")
+done
+
+gh "${args[@]}"

--- a/scripts/gh/create_pr_from_template.sh
+++ b/scripts/gh/create_pr_from_template.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 4 ]]; then
+  echo "usage: $0 <base> <head> <title> <body-file> [--draft]" >&2
+  exit 1
+fi
+
+base="$1"
+head="$2"
+title="$3"
+body_file="$4"
+shift 4
+
+if [[ ! -f "$body_file" ]]; then
+  echo "error: body file not found: $body_file" >&2
+  exit 1
+fi
+
+args=(pr create --base "$base" --head "$head" --title "$title" --body-file "$body_file")
+if [[ "${1:-}" == "--draft" ]]; then
+  args+=(--draft)
+fi
+
+gh "${args[@]}"


### PR DESCRIPTION
## Summary
- add parent/child issue templates and PR template
- add helper scripts that create issues/PRs via `--body-file`
- document template workflow to avoid shell expansion issues

## CodeRabbit
Optional (template/script/process-only change).