### PR TITLE
docs(process): require temporary-vs-final declaration in PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,15 +11,19 @@
 - [ ] Local checks passed
 - [ ] Added/updated tests where needed
 
-## Temporary Behavior (if any)
-- N/A
+## Temporary Behavior
+- [ ] None
+- [ ] Present (describe clearly below)
+- Description:
 
 ## Final Behavior
 - 
 
 ## Follow-up Issue/PR (if any)
-- N/A
+- [ ] None
+- [ ] Required (link issue/PR)
+- Link:
 
 ## CodeRabbit Policy
-- [ ] Required
-- [ ] Optional (process/docs-only change)
+- [ ] Required (product/API/auth/worker behavior changed)
+- [ ] Optional (process/docs/template/script-only change)

--- a/specs/007-clerk-auth-zpe-relax/tasks.md
+++ b/specs/007-clerk-auth-zpe-relax/tasks.md
@@ -37,3 +37,8 @@
 
 ## Optional Research
 - [ ] T760 [P] (#158) Produce orchestration comparison memo in `investigations/`
+
+## PR Transparency Rule (Definition of Done Addendum)
+- [ ] Every implementation PR must include both `Temporary Behavior` and `Final Behavior` sections.
+- [ ] If temporary behavior exists, PR must link a concrete follow-up issue/PR before merge.
+- [ ] Child issue cannot be closed until temporary behavior is removed or explicitly accepted in the parent epic.


### PR DESCRIPTION
## Summary
- strengthen PR template with explicit temporary/final declaration
- require follow-up link when temporary behavior is shipped
- add DoD addendum in specs/007 tasks

## Stacking
- base branch: `chore/gh-templates` (depends on PR #163)

## CodeRabbit
Optional (process/spec-doc change).