### PR TITLE
feat(web): migrate ToolPanel auth/session flow to Clerk (#155)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@chem-model/api-client": "workspace:*",
     "@chem-model/shared": "workspace:*",
+    "@clerk/clerk-react": "^5.60.0",
     "@faker-js/faker": "^10.0.0",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-label": "^2.1.2",

--- a/apps/web/src/lib/clerk-token-bridge.tsx
+++ b/apps/web/src/lib/clerk-token-bridge.tsx
@@ -1,0 +1,23 @@
+import { useAuth } from '@clerk/clerk-react'
+import { useEffect } from 'react'
+
+import { setApiTokenProvider } from './api'
+
+/** Clerk のセッショントークンを API クライアントへ橋渡しする。 */
+export function ClerkTokenBridge() {
+  const { isSignedIn, getToken } = useAuth()
+
+  useEffect(() => {
+    setApiTokenProvider(async () => {
+      if (!isSignedIn) {
+        return null
+      }
+      return getToken()
+    })
+    return () => {
+      setApiTokenProvider(null)
+    }
+  }, [getToken, isSignedIn])
+
+  return null
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,4 +1,5 @@
 import { Suspense, lazy } from 'react'
+import { ClerkProvider } from '@clerk/clerk-react'
 import {
   HeadContent,
   Outlet,
@@ -7,6 +8,7 @@ import {
 } from '@tanstack/react-router'
 
 import Header from '../components/Header'
+import { ClerkTokenBridge } from '../lib/clerk-token-bridge'
 import '../styles.css'
 
 import type { ReactNode } from 'react'
@@ -17,6 +19,9 @@ const runtimeApiBase = import.meta.env.SSR
     import.meta.env.VITE_API_BASE ??
     'http://localhost:8000')
   : null
+
+const clerkPublishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
+const clerkKey = clerkPublishableKey ?? 'pk_test_missing'
 
 const RouterDevtoolsPanel = import.meta.env.DEV
   ? lazy(() =>
@@ -40,8 +45,14 @@ export const Route = createRootRoute({
 })
 
 function RootLayout() {
-  return (
-    <RootDocument>
+  const appShell = (
+    <>
+      <ClerkTokenBridge />
+      {!clerkPublishableKey ? (
+        <div className="border-b border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+          VITE_CLERK_PUBLISHABLE_KEY is not set. Clerk auth will not be usable.
+        </div>
+      ) : null}
       <Header />
       <Outlet />
       {Devtools && RouterDevtoolsPanel ? (
@@ -59,6 +70,12 @@ function RootLayout() {
           />
         </Suspense>
       ) : null}
+    </>
+  )
+
+  return (
+    <RootDocument>
+      <ClerkProvider publishableKey={clerkKey}>{appShell}</ClerkProvider>
     </RootDocument>
   )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@chem-model/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@clerk/clerk-react':
+        specifier: ^5.60.0
+        version: 5.60.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@faker-js/faker':
         specifier: ^10.0.0
         version: 10.2.0
@@ -843,6 +846,25 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@clerk/clerk-react@5.60.0':
+    resolution: {integrity: sha512-P88FncsJpq/3WZJhhlj+md8mYb35BIXpr462C/figwsBGHsinr8VuBQUMcMZZ/6M34C8ABfLTPa6PHVp6+3D5Q==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+
+  '@clerk/shared@3.44.0':
+    resolution: {integrity: sha512-kH+chNeZwqml3IDpWLgebWECfOZifyUQO4OISd/96w1EuCY1Bzw6cBq/ZbpsoO8jyG8/6bGr/MGXLhDzTrpPfA==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   '@cloudflare/kv-asset-handler@0.4.2':
     resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
@@ -3973,6 +3995,9 @@ packages:
     resolution: {integrity: sha512-legscpSpgSAeGEe0TNcai97DKt9Vd9AsAdOL7Uoetb52Ar/8eJm3LIa39qpv8wWzLFlNG4vVvppQM+teaMPj3A==}
     engines: {node: '>=20'}
 
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -4648,6 +4673,9 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob-to-regexp@0.4.1:
+    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     hasBin: true
@@ -5111,6 +5139,10 @@ packages:
 
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+
+  js-cookie@3.0.5:
+    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
+    engines: {node: '>=14'}
 
   js-levenshtein@1.1.6:
     resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
@@ -6467,6 +6499,11 @@ packages:
 
   swap-case@1.1.2:
     resolution: {integrity: sha512-BAmWG6/bx8syfc6qXPprof3Mn5vQgf5dwdUNJhsNqU9WdPt5P+ES/wQ5bxfijy8zwZgZZHslC3iAsxsuQMCzJQ==}
+
+  swr@2.3.4:
+    resolution: {integrity: sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -7902,6 +7939,25 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@clerk/clerk-react@5.60.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@clerk/shared': 3.44.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      tslib: 2.8.1
+
+  '@clerk/shared@3.44.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      csstype: 3.1.3
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.5
+      std-env: 3.10.0
+      swr: 2.3.4(react@19.2.3)
+    optionalDependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@cloudflare/kv-asset-handler@0.4.2': {}
 
@@ -10989,6 +11045,8 @@ snapshots:
       css-tree: 3.1.0
       lru-cache: 11.2.4
 
+  csstype@3.1.3: {}
+
   csstype@3.2.3: {}
 
   data-urls@6.0.0:
@@ -11872,6 +11930,8 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob-to-regexp@0.4.1: {}
+
   glob@10.5.0:
     dependencies:
       foreground-child: 3.3.1
@@ -12351,6 +12411,8 @@ snapshots:
   jiti@2.6.1: {}
 
   jju@1.4.0: {}
+
+  js-cookie@3.0.5: {}
 
   js-levenshtein@1.1.6: {}
 
@@ -14120,6 +14182,12 @@ snapshots:
     dependencies:
       lower-case: 1.1.4
       upper-case: 1.1.3
+
+  swr@2.3.4(react@19.2.3):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
 
   symbol-tree@3.2.4: {}
 


### PR DESCRIPTION
## Summary
- integrate Clerk provider at app root and add token bridge for API requests
- remove legacy local auth form/session flow from ZPE ToolPanel
- switch sign-in/out UI to Clerk actions and keep queue/compute workflow behind Clerk auth

## Linked Issues
- Parent: #151
- Child: #155
- Depends on: #154 / PR #166

## Changes
- Added `@clerk/clerk-react`
- Added `apps/web/src/lib/clerk-token-bridge.tsx`
- Updated `apps/web/src/lib/api.ts` to attach async Clerk token provider
- Migrated ToolPanel account block from local auth fields to Clerk sign-in/sign-out

## Validation
- [x] `pnpm -C apps/web typecheck`

## Temporary Behavior
- [ ] None
- [x] Present (describe clearly below)
- Description: If `VITE_CLERK_PUBLISHABLE_KEY` is missing, app shows a warning banner and Clerk auth remains unusable.

## Final Behavior
- In deployed envs with `VITE_CLERK_PUBLISHABLE_KEY` configured, users sign in through Clerk and protected API calls include Clerk Bearer tokens.

## Follow-up Issue/PR (if any)
- [ ] None
- [x] Required (link issue/PR)
- Link: #156

## CodeRabbit Policy
- [x] Required (product/API/auth/worker behavior changed)
- [ ] Optional (process/docs/template/script-only change)
