### PR TITLE
feat(zpe): support minimal qe.relax.v1 on existing worker flow (#157)

### DIFF
--- a/apps/api/app/schemas/zpe.py
+++ b/apps/api/app/schemas/zpe.py
@@ -21,6 +21,7 @@ class ZPEParseResponse(ApiModel):
 
 
 class ZPEJobRequest(ApiModel):
+    calc_type: Literal["qe.zpe.v1", "qe.relax.v1"] = "qe.zpe.v1"
     content: str
     mobile_indices: List[int]
     use_environ: bool = False
@@ -40,6 +41,7 @@ class ZPEJobStatus(ApiModel):
 
 
 class ZPEResult(ApiModel):
+    calc_type: Literal["qe.zpe.v1", "qe.relax.v1"] = "qe.zpe.v1"
     freqs_cm: List[float]
     zpe_ev: float
     s_vib_jmol_k: float

--- a/apps/api/services/zpe/backends.py
+++ b/apps/api/services/zpe/backends.py
@@ -65,6 +65,7 @@ def _run_mock_job(payload: Dict[str, Any], store: ResultStore) -> str:
 
     now = _now_iso()
     result: Dict[str, Any] = {
+        "calc_type": request.calc_type,
         "freqs_cm": normalize_frequencies(freqs_cm),
         "zpe_ev": zpe_ev,
         "s_vib_jmol_k": s_vib_jmol_k,

--- a/apps/api/services/zpe/worker.py
+++ b/apps/api/services/zpe/worker.py
@@ -109,6 +109,7 @@ def _compute_mock_artifacts(
 
     now = datetime.now(timezone.utc).isoformat()
     result: Dict[str, Any] = {
+        "calc_type": request.calc_type,
         "freqs_cm": normalize_frequencies(freqs_cm),
         "zpe_ev": zpe_ev,
         "s_vib_jmol_k": s_vib_jmol_k,
@@ -269,6 +270,7 @@ def compute_zpe_artifacts(payload: Dict[str, Any], *, job_id: str) -> ZPECompute
     checked_files = int(checked_raw) if isinstance(checked_raw, (int, float)) else 0
     deleted_files = int(deleted_raw) if isinstance(deleted_raw, (int, float)) else 0
     result: Dict[str, Any] = {
+        "calc_type": request.calc_type,
         "freqs_cm": normalize_frequencies(freqs_cm),
         "zpe_ev": zpe_ev,
         "s_vib_jmol_k": s_vib_jmol_k,

--- a/apps/web/src/features/editor-v2/components/ToolPanel.tsx
+++ b/apps/web/src/features/editor-v2/components/ToolPanel.tsx
@@ -551,6 +551,7 @@ function ZpeToolPanel({ files = [] }: { files?: Array<WorkspaceFile> }) {
     setJobResult(null)
     try {
       const response = await createZpeJob({
+        calc_type: 'qe.zpe.v1',
         content: selectedFile.qeInput,
         mobile_indices: Array.from(mobileIndices).sort((a, b) => a - b),
         use_environ: useEnviron,

--- a/packages/api-client/openapi/openapi.json
+++ b/packages/api-client/openapi/openapi.json
@@ -1164,6 +1164,15 @@
             "title": "Calc Mode",
             "type": "string"
           },
+          "calc_type": {
+            "default": "qe.zpe.v1",
+            "enum": [
+              "qe.zpe.v1",
+              "qe.relax.v1"
+            ],
+            "title": "Calc Type",
+            "type": "string"
+          },
           "content": {
             "title": "Content",
             "type": "string"
@@ -1367,6 +1376,15 @@
           },
           "calc_start_time": {
             "title": "Calc Start Time",
+            "type": "string"
+          },
+          "calc_type": {
+            "default": "qe.zpe.v1",
+            "enum": [
+              "qe.zpe.v1",
+              "qe.relax.v1"
+            ],
+            "title": "Calc Type",
             "type": "string"
           },
           "delta": {

--- a/packages/api-client/src/generated/schema.ts
+++ b/packages/api-client/src/generated/schema.ts
@@ -801,6 +801,12 @@ export interface components {
              * @enum {string}
              */
             calc_mode: "new" | "continue";
+            /**
+             * Calc Type
+             * @default qe.zpe.v1
+             * @enum {string}
+             */
+            calc_type: "qe.zpe.v1" | "qe.relax.v1";
             /** Content */
             content: string;
             /** Input Dir */
@@ -866,6 +872,12 @@ export interface components {
             calc_end_time: string;
             /** Calc Start Time */
             calc_start_time: string;
+            /**
+             * Calc Type
+             * @default qe.zpe.v1
+             * @enum {string}
+             */
+            calc_type: "qe.zpe.v1" | "qe.relax.v1";
             /** Delta */
             delta: number;
             /** Ecutrho */


### PR DESCRIPTION
## Summary
- add `calc_type` to ZPE job contract with support for `qe.zpe.v1` and minimal `qe.relax.v1`
- propagate `calc_type` through mock/worker result payloads
- add regression test for `qe.relax.v1` enqueue/run/result path
- refresh OpenAPI + generated api-client schema for the updated job contract

## Linked Issues
- Parent: #151
- Child: #157
- Depends on: #156 / PR #168

## Changes
- API schema: `ZPEJobRequest.calc_type`, `ZPEResult.calc_type`
- Worker/backend result payload includes `calc_type`
- Web ZPE submit path explicitly sends `calc_type: qe.zpe.v1`

## Validation
- [x] `uv run --project apps/api pytest apps/api/tests/test_zpe_api.py apps/api/tests/test_zpe_http_worker_integration.py apps/api/tests/test_zpe_http_queue.py apps/api/tests/test_zpe_lease_api.py`
- [x] `uv run --project apps/api pytest apps/api/tests/test_zpe_api.py`
- [x] `pnpm -C apps/web typecheck`

## Temporary Behavior
- [x] None
- [ ] Present (describe clearly below)
- Description:

## Final Behavior
- Existing ZPE path stays intact (`qe.zpe.v1`) and minimal `qe.relax.v1` jobs can now be accepted and executed on the same worker path.

## Follow-up Issue/PR (if any)
- [x] None
- [ ] Required (link issue/PR)
- Link:

## CodeRabbit Policy
- [x] Required (product/API/auth/worker behavior changed)
- [ ] Optional (process/docs/template/script-only change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added calculation type selection for ZPE jobs, enabling users to choose between standard zero-point energy calculations (qe.zpe.v1) and structure relaxation calculations (qe.relax.v1). The selected calculation type is now included in job requests and results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->