### PR TITLE
fix(api): restore main CI after epic #151 merge sequence

### DIFF
--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -9,8 +9,8 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-import app.deps as deps
-from services.authn.settings import AuthnSettings
+import app.deps as deps  # noqa: E402
+from services.authn.settings import AuthnSettings  # noqa: E402
 
 
 @pytest.fixture(autouse=True)

--- a/apps/api/tests/test_zpe_queue_targets.py
+++ b/apps/api/tests/test_zpe_queue_targets.py
@@ -87,7 +87,7 @@ def test_queue_target_list_and_select(monkeypatch):
 
 
 def test_queue_target_visibility_is_scoped_by_user(monkeypatch):
-    fake = _patch_redis(monkeypatch)
+    _patch_redis(monkeypatch)
     client = TestClient(main.app)
     owner_headers = {
         "X-Dev-User-Id": "user-owner",


### PR DESCRIPTION
## Summary
- fix Ruff `E402` in `apps/api/tests/conftest.py` by explicitly marking post-path imports
- fix Ruff `F841` in `apps/api/tests/test_zpe_queue_targets.py` by removing an unused variable
- restore `api` CI job execution path so mypy/pytest/schemathesis are no longer skipped

## Linked Issues
- #170
- #151

## Changes
- `apps/api/tests/conftest.py`
- `apps/api/tests/test_zpe_queue_targets.py`

## Validation
- [x] `cd apps/api && uv run ruff check .`
- [x] `cd apps/api && uv run mypy .`
- [x] `cd apps/api && uv run pytest`
- [x] `cd apps/api && SCHEMATHESIS_PORT=8011 uv run bash scripts/schemathesis.sh`
- [x] `pnpm exec nx run web:lint`
- [x] `pnpm exec nx run web:typecheck`
- [x] `pnpm exec nx run web:test`

## Temporary Behavior
- [x] None
- [ ] Present (describe clearly below)
- Description:

## Final Behavior
- Mainline CI no longer fails on the post-merge Ruff regressions introduced during epic #151 rollout.

## Follow-up Issue/PR (if any)
- [ ] None
- [x] Required (link issue/PR)
- Link: #170 (remaining tasks: CodeRabbit backfill + branch protection hardening)

## CodeRabbit Policy
- [x] Required (product/API/auth/worker behavior changed)
- [ ] Optional (process/docs/template/script-only change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures with linting annotations to improve code quality standards.
  * Refined test implementation for queue target visibility validation.

---

*Note: These changes are internal maintenance improvements with no impact on user-facing functionality.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->