### PR TITLE
fix(api): correct lease key arg index in ZPE lease script

### DIFF
--- a/apps/api/services/zpe/lease.py
+++ b/apps/api/services/zpe/lease.py
@@ -56,7 +56,7 @@ def lease_next_job(worker_id: str) -> Optional[Lease]:
     script = (
         "local job_id = redis.call('RPOP', KEYS[1])\n"
         "if not job_id then return nil end\n"
-        "local lease_key = ARGV[5] .. job_id\n"
+        "local lease_key = ARGV[6] .. job_id\n"
         "redis.call('HSET', lease_key, 'worker_id', ARGV[1], 'lease_id', ARGV[2], 'expires_at', ARGV[3])\n"
         "redis.call('EXPIRE', lease_key, ARGV[4])\n"
         "redis.call('ZADD', KEYS[2], ARGV[5], job_id)\n"


### PR DESCRIPTION
## Summary
- fix Lua argv index when composing `lease_key` in `lease_next_job`
- ensure leased jobs are written to `zpe:lease:{job_id}` correctly

## Why
Workers could receive jobs but later fail to submit status/result with `lease not found` due to incorrect key construction.

## Validation
- `uv run --project apps/api pytest apps/api/tests/test_zpe_lease_api.py apps/api/tests/test_zpe_compute_results.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined internal job lease key construction to align parameter configurations in the background job processing system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->