### PR TITLE
docs: fix clone URL owner in README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -11,7 +11,7 @@ Quantum ESPRESSO `.in` の構造を可視化・編集するWebアプリ。
 コマンドは repo root で実行します。
 
 ```bash
-git clone git@github.com:Grac11111aq/chem-model-edit.git
+git clone git@github.com:grace-bidos/chem-model-edit.git
 cd chem-model-edit
 
 ./scripts/setup-dev.sh

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Detailed scope and acceptance criteria: `specs/001-chem-model-webapp/spec.md`.
 Run from repository root.
 
 ```bash
-git clone git@github.com:Grac11111aq/chem-model-edit.git
+git clone git@github.com:grace-bidos/chem-model-edit.git
 cd chem-model-edit
 
 ./scripts/setup-dev.sh


### PR DESCRIPTION
## Summary
- replace old clone URL owner Grac11111aq with grace-bidos
- update both English and Japanese README quickstart snippets

## Files
- README.md
- README.ja.md
