### PR TITLE
GRA-35: document post-merge local main sync in PR loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,10 +56,10 @@ Primary capabilities include parallel structure views, partial structure transpl
 - Use `--resolve-outdated-threads` only for outdated threads; do not auto-resolve active review discussions.
 - Prefer this script over ad-hoc manual polling when handling repeated CI/review feedback cycles.
 - If `--delete-branch` fails because the branch is attached to an active worktree, clean it up manually after removing the worktree.
-- After a PR is merged, always sync local `main` immediately as part of the same operation set:
+- After a PR is merged, always sync local `main` immediately as part of the same operation set.
+- Worktree-safe sync from any worktree:
   - `git fetch origin --prune`
-  - `git checkout main`
-  - `git pull --ff-only origin main`
+  - `git -C "$(git rev-parse --show-toplevel)" merge --ff-only origin/main`
 
 ## Repository Layout
 - `apps/web`: TanStack Start frontend


### PR DESCRIPTION
## Summary
- add an explicit post-merge local `main` sync step to the PR loop operation in `AGENTS.md`
- clarify that merge and local main synchronization are one operation set

## Work Item Metadata
- Linear Issue: GRA-35
- Type: Ship
- Size: XS
- Queue Policy: Optional
- Stack: Standalone

## Linked Issues
- Linear: https://linear.app/grace-----aq/issue/GRA-35/document-post-merge-main-sync-step-in-agents-pr-loop-operation

## Changes
- Updated `AGENTS.md` in `PR Loop Operation (Recommended)`:
  - `git fetch origin --prune`
  - `git checkout main`
  - `git pull --ff-only origin main`

## Validation
- [x] Local checks passed
- [ ] Added/updated tests where needed
- Note: docs-only update.

## Temporary Behavior
- [x] None
- [ ] Present (describe clearly below)
- Description:

## Final Behavior
- PR loop guidance now includes the explicit local main synchronization step after merge.

## Follow-up Issue/PR (if any)
- [x] None
- [ ] Required (link issue/PR)
- Link:

## CodeRabbit Policy
- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pull request workflow documentation with enhanced post-merge synchronization procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->