### PR TITLE
GRA-36: fix malformed GraphQL query in pr-autoloop

### DIFF
--- a/scripts/gh/pr-autoloop.py
+++ b/scripts/gh/pr-autoloop.py
@@ -75,17 +75,33 @@ def get_pr(pr_number: int) -> dict[str, Any]:
 
 def get_unresolved_threads(pr_number: int) -> list[ThreadInfo]:
     owner, repo = get_repo_owner_name()
-    query = (
-        "query($owner:String!,$repo:String!,$num:Int!,$after:String){"
-        "repository(owner:$owner,name:$repo){"
-        "pullRequest(number:$num){"
-        "reviewThreads(first:100, after:$after){"
-        "nodes{"
-        "id isResolved isOutdated "
-        "comments(first:1){nodes{author{login} url}}"
-        "} pageInfo{hasNextPage endCursor}"
-        "}}}}}"
-    )
+    query = """
+query($owner:String!, $repo:String!, $num:Int!, $after:String) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$num) {
+      reviewThreads(first:100, after:$after) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          comments(first:1) {
+            nodes {
+              author {
+                login
+              }
+              url
+            }
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+""".strip()
     unresolved: list[ThreadInfo] = []
     cursor: str | None = None
 


### PR DESCRIPTION
## Summary
- fix malformed GraphQL query formatting in `scripts/gh/pr-autoloop.py`
- switch unresolved-thread query to a multiline GraphQL document with explicit field blocks
- keep pagination behavior while removing brace-balance risk from string concatenation

## Work Item Metadata
- Linear Issue: GRA-36
- Type: Ship
- Size: XS
- Queue Policy: Optional
- Stack: Standalone

## Linked Issues
- Linear: https://linear.app/grace-----aq/issue/GRA-36/fix-graphql-query-formatting-bug-in-pr-auto-loop-unresolved-thread

## Changes
- Updated `get_unresolved_threads` query construction in `scripts/gh/pr-autoloop.py`
- No behavior change intended outside query parsing reliability

## Validation
- [x] Local checks passed
- [ ] Added/updated tests where needed
- Verified:
  - `python3 -m py_compile scripts/gh/pr-autoloop.py`
  - `scripts/gh/pr-autoloop.py 231`

## Temporary Behavior
- [x] None
- [ ] Present (describe clearly below)
- Description:

## Final Behavior
- PR auto-loop can fetch unresolved review threads without GraphQL parse failures.

## Follow-up Issue/PR (if any)
- [x] None
- [ ] Required (link issue/PR)
- Link:

## CodeRabbit Policy
- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)
