### PR TITLE
GRA-12: ADR for system-of-record boundaries and ownership model

### DIFF
--- a/docs/adr/ADR-0001-system-of-record-boundaries.md
+++ b/docs/adr/ADR-0001-system-of-record-boundaries.md
@@ -1,0 +1,47 @@
+# ADR-0001: System-of-Record Boundaries and Ownership Model
+
+- Status: Accepted
+- Date: 2026-02-15
+- Linear: `GRA-12`
+- Owners: Backend platform
+
+## Context
+
+Backend refresh introduces multiple persistence and orchestration surfaces (`Convex`, `AiiDA/Postgres`, FastAPI adapter, and transitional Redis paths). Without explicit ownership, runtime behavior can diverge across systems and create ambiguous truth sources.
+
+## Decision
+
+Define clear ownership boundaries:
+
+- `AiiDA/Postgres` is the system of record for scientific workflow execution internals.
+- `Convex` is the system of record for product-facing job projection and UI read models.
+- `FastAPI` is a thin adapter/orchestration layer and is not a long-term source of truth.
+- `Redis` is transitional transport/cache/lease infrastructure only; it must not be treated as durable truth.
+
+Ownership by concern:
+
+- Job execution internals (scheduler/runtime metadata): `AiiDA/Postgres`
+- User-visible job lifecycle and query model: `Convex`
+- Authentication/session data (current implementation): dedicated auth store
+- Queue lease and transient delivery state: Redis (temporary)
+
+## Consequences
+
+- All new backend-refresh features must choose one durable owner (`AiiDA/Postgres` or `Convex`) for each persisted field.
+- Adapter-level writes must be projection or command-routing oriented, not ownership-oriented.
+- Migration work (`GRA-21`, `GRA-22`) must remove Redis-owned business semantics.
+
+## Implementation Notes
+
+- `GRA-14`, `GRA-16`, `GRA-18`, `GRA-20` must preserve the ownership split above.
+- API contracts exposed to clients should be modeled from Convex-facing read models.
+- Scientific execution write paths should terminate in AiiDA/Postgres-owned structures.
+
+## Verification
+
+- For each runtime PR, include a short "SoR mapping" table in PR description:
+  - field/aggregate
+  - owner
+  - write path
+  - read path
+- Reject PRs that introduce dual-write ambiguity without an explicit migration contract.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,11 @@
+# Architecture Decision Records
+
+This directory stores architecture decisions that are binding for backend refresh work.
+
+- `ADR-0001`: System-of-record boundaries and ownership model (`GRA-12`)
+
+Rules:
+
+- New runtime-impacting architecture decisions must be captured in a new ADR.
+- Superseding a decision requires a new ADR that references the old one.
+- Implementation PRs touching these boundaries must link the relevant ADR.

--- a/docs/process/linear-stacked-pr-operating-model.md
+++ b/docs/process/linear-stacked-pr-operating-model.md
@@ -137,6 +137,10 @@ Optional post-merge checks (expand later):
 - Stack C (migration and operations):
   - `GRA-21` -> `GRA-22` -> `GRA-19` -> `GRA-23` -> `GRA-24` -> `GRA-25`
 
+### 8.5 Accepted ADRs for backend refresh foundations
+
+- `GRA-12`: `docs/adr/ADR-0001-system-of-record-boundaries.md`
+
 ## 9. Review bottleneck controls
 
 - Keep stack depth typically <= 4 PRs when possible.


### PR DESCRIPTION
## Summary
- add ADR-0001 to define system-of-record boundaries for backend refresh
- document ownership split across AiiDA/Postgres, Convex, FastAPI adapter, and Redis transition paths
- add ADR index and link accepted ADR in process document

## Work Item Metadata
- Linear Issue: GRA-12
- Type: Ask
- Size: S
- Queue Policy: Optional
- Stack: Base

## Linked Issues
- https://linear.app/grace-----aq/issue/GRA-12/adr-system-of-record-boundaries-and-ownership-model

## Changes
- add `docs/adr/ADR-0001-system-of-record-boundaries.md`
- add `docs/adr/README.md`
- update `docs/process/linear-stacked-pr-operating-model.md`

## Validation
- [x] Local checks passed
- [x] Added/updated tests where needed

## Temporary Behavior
- [x] None
- [ ] Present (describe clearly below)
- Description:

## Final Behavior
- backend-refresh work now has explicit SoR/ownership boundaries before runtime migration layers proceed

## Follow-up Issue/PR (if any)
- [x] None
- [ ] Required (link issue/PR)
- Link:

## CodeRabbit Policy
- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)
