### PR TITLE
docs: fix remaining markdownlint issues in docs

### DIFF
--- a/docs/clerk-migration-kickoff.md
+++ b/docs/clerk-migration-kickoff.md
@@ -10,5 +10,6 @@ This document links the planning artifacts for the one-shot Clerk migration epic
 - Planning tasks: `specs/007-clerk-auth-zpe-relax/tasks.md`
 
 Policy:
+
 - Use child-issue-scoped small PRs to keep CodeRabbit review turnaround fast.
 - Reflect architecture-impact feedback in both spec and plan docs.

--- a/docs/zpe-worker-setup.ja.md
+++ b/docs/zpe-worker-setup.ja.md
@@ -4,21 +4,25 @@
 control-plane（FastAPI）はジョブ投入のみを行い、QE 計算は compute-plane に委譲します。
 
 ## 構成
+
 - **control-plane**: FastAPI API（Cloud Run など）
 - **compute-plane**: HTTP worker（別マシン）
 - **共有ストア**: Redis（control-plane のみが接続）
 
 ## 秘密情報の境界
+
 - **Admin token** は control-plane のみで保持
 - **compute-plane** は短期 enroll token を使って登録
 
 ## 前提（compute-plane）
+
 - Python >= 3.13（`uv` 使用）
 - Quantum ESPRESSO（`pw.x`）が利用可能
 - Pseudopotential ディレクトリ
 - control-plane へ HTTPS で到達可能
 
 ## リポジトリと Python 環境
+
 ```bash
 # SSH (事前にSSH鍵の設定が必要)
 git clone git@github.com:grace-bidos/chem-model-edit.git
@@ -29,13 +33,16 @@ uv sync
 ```
 
 ## 環境変数ファイル
+
 control-plane と compute-plane を分離します。
 
 - control-plane: `apps/api/.env.control.example`
 - compute-plane: `apps/api/.env.compute.example`
 
 ### Control-plane（FastAPI）
+
 remote-http 用の最小例:
+
 ```bash
 ZPE_REDIS_URL=redis://localhost:6379/0
 ZPE_QUEUE_NAME=zpe
@@ -45,7 +52,9 @@ ZPE_ADMIN_TOKEN=change-me
 ```
 
 ### Compute-plane（worker）
+
 QE 実行に必要な最小例:
+
 ```bash
 ZPE_CONTROL_API_URL=http://localhost:8000
 ZPE_WORKER_TOKEN=change-me
@@ -54,6 +63,7 @@ ZPE_PW_PATH=/path/to/pw.x
 ```
 
 任意設定:
+
 - `ZPE_USE_MPI=true|false`
 - `ZPE_MPI_CMD=mpirun`
 - `ZPE_NP_CORE=12`
@@ -65,16 +75,20 @@ ZPE_PW_PATH=/path/to/pw.x
 ## Enroll token フロー（任意だが推奨）
 
 ### ユーザー自己発行（UI経由）
+
 1) Web UI でサインインし、Enroll token を発行（有効期限は約 1 時間）。
 2) compute-plane 登録時に queue 名を指定して登録:
+
 ```bash
 curl -X POST http://localhost:8000/calc/zpe/compute/servers/register \
   -H "Content-Type: application/json" \
   -d '{"token": "<ENROLL_TOKEN>", "name": "worker-1", "queue_name": "zpe", "meta": {"host": "compute-01"}}'
 ```
+
 登録された worker は UI のキューターゲット一覧に表示されます。
 
 ### 1) control-plane でトークン発行
+
 ```bash
 curl -X POST http://localhost:8000/calc/zpe/compute/enroll-tokens \
   -H "Content-Type: application/json" \
@@ -83,6 +97,7 @@ curl -X POST http://localhost:8000/calc/zpe/compute/enroll-tokens \
 ```
 
 ### 2) compute-plane 登録
+
 ```bash
 curl -X POST http://localhost:8000/calc/zpe/compute/servers/register \
   -H "Content-Type: application/json" \
@@ -90,17 +105,21 @@ curl -X POST http://localhost:8000/calc/zpe/compute/servers/register \
 ```
 
 ## Worker 起動
+
 補助スクリプトを用意しています:
+
 ```bash
 ./scripts/run-zpe-worker.sh
 ```
 
 HTTP ワーカーの場合:
+
 ```bash
 ./scripts/run-zpe-http-worker.sh
 ```
 
 特定の env ファイルを指定する場合:
+
 ```bash
 ZPE_ENV_FILE=apps/api/.env.compute ./scripts/run-zpe-worker.sh
 ```
@@ -111,12 +130,14 @@ ZPE_ENV_FILE=apps/api/.env.compute ./scripts/run-zpe-worker.sh
 停止しても **進行中ジョブは継続** し、キューからの新規取得だけが抑制されます。
 
 状態確認:
+
 ```bash
 curl -H "Authorization: Bearer $ZPE_ADMIN_TOKEN" \
   http://localhost:8000/calc/zpe/admin/ops
 ```
 
 新規受付を停止:
+
 ```bash
 curl -X POST http://localhost:8000/calc/zpe/admin/ops \
   -H "Content-Type: application/json" \
@@ -125,6 +146,7 @@ curl -X POST http://localhost:8000/calc/zpe/admin/ops \
 ```
 
 worker dequeue を停止:
+
 ```bash
 curl -X POST http://localhost:8000/calc/zpe/admin/ops \
   -H "Content-Type: application/json" \
@@ -133,6 +155,7 @@ curl -X POST http://localhost:8000/calc/zpe/admin/ops \
 ```
 
 再開:
+
 ```bash
 curl -X POST http://localhost:8000/calc/zpe/admin/ops \
   -H "Content-Type: application/json" \
@@ -141,28 +164,34 @@ curl -X POST http://localhost:8000/calc/zpe/admin/ops \
 ```
 
 `just` を使う場合:
+
 ```bash
 just zpe-worker
 ```
 
 HTTP ワーカーの場合:
+
 ```bash
 just zpe-http-worker
 ```
 
 起動時に `uv sync` も実行する場合:
+
 ```bash
 ZPE_WORKER_SYNC=1 ./scripts/run-zpe-worker.sh
 ```
 
 ## スモークテスト（E2E）
+
 1) API 起動（control-plane）
+
 ```bash
 cd apps/api
 uv run uvicorn main:app --reload --port 8000
 ```
 
-2) ジョブ投入（別ターミナル・repo root で実行）
+1) ジョブ投入（別ターミナル・repo root で実行）
+
 ```bash
 python - <<'PY'
 import json
@@ -188,22 +217,29 @@ print(urllib.request.urlopen(req).read().decode())
 PY
 ```
 
-3) ステータス確認と結果取得
+1) ステータス確認と結果取得
+
 ```bash
 curl http://localhost:8000/calc/zpe/jobs/<JOB_ID>
 curl http://localhost:8000/calc/zpe/jobs/<JOB_ID>/result
 ```
 
 ## Mock mode（control-plane のみ）
+
 E2E/CI 向けに worker を不要にする場合:
+
 ```bash
 ZPE_COMPUTE_MODE=mock
 ```
+
 決定論的なダミー結果が返るため、compute-plane は不要です。
 
 ## Worker 側の mock 実行（遠隔経路の検証用）
+
 **遠隔キュー経路**を通しつつ QE を避けたい場合は compute-plane に以下を設定します:
+
 ```bash
 ZPE_WORKER_MODE=mock
 ```
+
 API 側は `ZPE_COMPUTE_MODE=remote-queue` のままにします。

--- a/docs/zpe-worker-setup.md
+++ b/docs/zpe-worker-setup.md
@@ -4,21 +4,25 @@ This guide explains how to run the ZPE compute worker on a separate machine.
 The control-plane (FastAPI) only enqueues jobs and never runs QE locally.
 
 ## Architecture
+
 - **Control-plane**: FastAPI API on Cloud Run (or any host)
 - **Compute-plane**: HTTP worker on a separate machine
 - **Shared store**: Redis (control-plane only)
 
 ## Secret boundary
+
 - **Admin token** stays in the control-plane only.
 - **Compute-plane** uses a short-lived enroll token to register itself.
 
 ## Prerequisites (compute-plane)
+
 - Python >= 3.13 with `uv`
 - Quantum ESPRESSO (`pw.x`) installed
 - Pseudopotential directory
 - Reachable control-plane over HTTPS
 
 ## Repo + Python env
+
 ```bash
 git clone git@github.com:grace-bidos/chem-model-edit.git
 # or HTTPS
@@ -28,13 +32,16 @@ uv sync
 ```
 
 ## Environment files
+
 Use separate env files for control-plane and compute-plane.
 
 - Control-plane example: `apps/api/.env.control.example`
 - Compute-plane example: `apps/api/.env.compute.example`
 
 ### Control-plane (FastAPI)
+
 Minimal config for remote-http:
+
 ```bash
 ZPE_REDIS_URL=redis://localhost:6379/0
 ZPE_QUEUE_NAME=zpe
@@ -44,7 +51,9 @@ ZPE_ADMIN_TOKEN=change-me
 ```
 
 ### Compute-plane (worker)
+
 Minimal config for QE execution:
+
 ```bash
 ZPE_CONTROL_API_URL=http://localhost:8000
 ZPE_WORKER_TOKEN=change-me
@@ -53,6 +62,7 @@ ZPE_PW_PATH=/path/to/pw.x
 ```
 
 Optional:
+
 - `ZPE_USE_MPI=true|false`
 - `ZPE_MPI_CMD=mpirun`
 - `ZPE_NP_CORE=12`
@@ -64,16 +74,20 @@ Optional:
 ## Enroll-token flow (optional but recommended)
 
 ### User self-service (UI-driven)
+
 1) Sign in on the web UI and generate an enroll token (valid for ~1 hour).
 2) Use the token on the compute server registration call with a queue name:
+
 ```bash
 curl -X POST http://localhost:8000/calc/zpe/compute/servers/register \
   -H "Content-Type: application/json" \
   -d '{"token": "<ENROLL_TOKEN>", "name": "worker-1", "queue_name": "zpe", "meta": {"host": "compute-01"}}'
 ```
+
 The server is registered under the signed-in user and becomes available as a queue target in the UI.
 
 ### 1) Create a token on the control-plane
+
 ```bash
 curl -X POST http://localhost:8000/calc/zpe/compute/enroll-tokens \
   -H "Content-Type: application/json" \
@@ -82,6 +96,7 @@ curl -X POST http://localhost:8000/calc/zpe/compute/enroll-tokens \
 ```
 
 ### 2) Register the compute server
+
 ```bash
 curl -X POST http://localhost:8000/calc/zpe/compute/servers/register \
   -H "Content-Type: application/json" \
@@ -89,44 +104,54 @@ curl -X POST http://localhost:8000/calc/zpe/compute/servers/register \
 ```
 
 ## Start the worker
+
 A helper script is provided:
+
 ```bash
 ./scripts/run-zpe-worker.sh
 ```
 
 For HTTP worker:
+
 ```bash
 ./scripts/run-zpe-http-worker.sh
 ```
 
 You can point it to a specific env file:
+
 ```bash
 ZPE_ENV_FILE=apps/api/.env.compute ./scripts/run-zpe-worker.sh
 ```
 
 If you use `just`:
+
 ```bash
 just zpe-worker
 ```
 
 For HTTP worker:
+
 ```bash
 just zpe-http-worker
 ```
 
 If you need to run `uv sync` at startup, set:
+
 ```bash
 ZPE_WORKER_SYNC=1 ./scripts/run-zpe-worker.sh
 ```
 
 ## Smoke test (end-to-end)
+
 1) Start the API (control-plane)
+
 ```bash
 cd apps/api
 uv run uvicorn main:app --reload --port 8000
 ```
 
-2) Submit a job (in another terminal, repo root)
+1) Submit a job (in another terminal, repo root)
+
 ```bash
 python - <<'PY'
 import json
@@ -152,23 +177,30 @@ print(urllib.request.urlopen(req).read().decode())
 PY
 ```
 
-3) Poll the job and fetch the result
+1) Poll the job and fetch the result
+
 ```bash
 curl http://localhost:8000/calc/zpe/jobs/<JOB_ID>
 curl http://localhost:8000/calc/zpe/jobs/<JOB_ID>/result
 ```
 
 ## Mock mode (control-plane only)
+
 For fast E2E/CI without a worker:
+
 ```bash
 ZPE_COMPUTE_MODE=mock
 ```
+
 The API returns deterministic dummy results, and no worker is required.
 
 ## Mock execution on the worker (remote-path test)
+
 If you want to test the **remote queue path** without running QE, set this on the compute-plane:
+
 ```bash
 ZPE_WORKER_MODE=mock
 ```
+
 The worker will dequeue jobs and write dummy results to Redis, while the API remains
 in `ZPE_COMPUTE_MODE=remote-queue`.


### PR DESCRIPTION
## Summary
- Apply markdownlint cleanup to remaining `docs/**/*.md` files (excluding already-cleaned setup guides).

## Work Item Metadata
- Linear Issue: GRA-10
- Type: Ship
- Size: S
- Queue Policy: Optional
- Stack: Standalone

## Linked Issues
- None

## Changes
- Fix markdownlint issues in:
  - `docs/clerk-migration-kickoff.md`
  - `docs/zpe-remote-worker-http-spec.ja.md`
  - `docs/zpe-worker-setup.ja.md`
  - `docs/zpe-worker-setup.md`
- Resolved rules such as heading/list/fence spacing and ordered-list style consistency.

## Validation
- [x] Local checks passed
- [ ] Added/updated tests where needed

## Temporary Behavior
- [x] None
- [ ] Present (describe clearly below)
- Description:

## Final Behavior
- `docs/**/*.md` passes markdown lint/format checks from root scripts.

## Follow-up Issue/PR (if any)
- [x] None
- [ ] Required (link issue/PR)
- Link:

## CodeRabbit Policy
- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)
