### PR TITLE
GRA-37: Add ADR for projection boundary and single-write cutover

### DIFF
--- a/docs/adr/ADR-0003-projection-boundary-and-single-write-cutover.md
+++ b/docs/adr/ADR-0003-projection-boundary-and-single-write-cutover.md
@@ -1,0 +1,62 @@
+# ADR-0003: Projection Boundary and Single-Write Cutover Policy
+
+- Status: Accepted
+- Date: 2026-02-15
+- Linear: `GRA-37`
+- Owners: Backend platform
+- Related: `GRA-16`, `GRA-20`, `GRA-21`, `GRA-22`, `GRA-24`
+
+## Context
+
+Backend refresh must keep product UX fast while preserving AiiDA strengths (provenance-rich execution internals). If we mirror AiiDA internals broadly into Convex, migration and feature cost will grow with every workflow detail added. We also need a clear migration policy from Redis that avoids prolonged dual-write ambiguity.
+
+## Decision
+
+Projection and ownership policy:
+
+- `Convex` remains product-facing system of record for UI read models and collaboration-facing metadata.
+- `AiiDA/Postgres` remains system of record for scientific execution internals and provenance graph details.
+- Use stable cross-reference keys (for example `aiida_node_id`) to join product projections with execution details.
+- Deep execution detail views must read from AiiDA through adapter endpoints on demand.
+- Do not bulk-mirror full AiiDA execution/provenance models into Convex.
+
+Field-level ownership clarifications for pending work:
+
+- Queue target profiles and active profile selection: `Convex` owner.
+- Worker authentication credentials:
+  - durable owner: dedicated auth store
+  - token format: opaque tokens
+  - storage: hashed-at-rest representation
+  - Redis may be used only as short-lived cache, not durable authority.
+
+Cutover policy:
+
+- Use single-write migration policy for runtime paths (`GRA-21`, `GRA-22`); no long-lived dual-write phase.
+- Transitional emergency-stop controls are allowed only as short-lived operations switches with explicit owner and expiry in PR description.
+- Redis stays limited to lease/transport/transient cache semantics.
+
+## Consequences
+
+- Product list/status flows stay fast by reading Convex projection models.
+- Detailed execution/provenance views require adapter calls to AiiDA sources.
+- Model-drift risk is reduced because Convex projection scope is intentionally narrow.
+- Migration sequencing becomes stricter: ownership must be explicit before write-path cutover.
+
+## Implementation Notes
+
+- `GRA-16`: event relay writes only product projection fields to Convex.
+- `GRA-20`: adapter surfaces summary-vs-detail boundaries explicitly.
+- `GRA-21`: cutover flags include temporary emergency-stop fields with expiry metadata.
+- `GRA-22`: remove Redis-owned business semantics from result/meta/ownership/auth paths.
+- `GRA-24`: restart durability must come from durable owners (`Convex` and/or `AiiDA/Postgres`), not Redis keys.
+
+## Verification
+
+- Runtime PRs must include:
+  - projection field list (what is stored in Convex)
+  - detail read path (where AiiDA is queried)
+  - cutover plan (single-write switch step and rollback behavior)
+- Reject PRs that:
+  - introduce broad AiiDA-to-Convex model mirroring
+  - reintroduce Redis as durable owner for business semantics
+  - add emergency-stop flags without explicit expiry/removal plan.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -4,6 +4,7 @@ This directory stores architecture decisions that are binding for backend refres
 
 - `ADR-0001`: System-of-record boundaries and ownership model (`GRA-12`)
 - `ADR-0002`: Canonical JobState contract and transition rules (`GRA-13`)
+- `ADR-0003`: Projection boundary and single-write cutover policy (`GRA-37`)
 
 Rules:
 

--- a/docs/process/linear-stacked-pr-operating-model.md
+++ b/docs/process/linear-stacked-pr-operating-model.md
@@ -126,6 +126,7 @@ Optional post-merge checks (expand later):
 
 - Cycle 1 (1 week) includes all backend-refresh execution issues:
   - `GRA-12` to `GRA-25` under `GRA-10`
+- `GRA-37` is a follow-up Ask ADR and is loaded independently when architecture clarification is required.
 - Specialized exploration (`GRA-26` to `GRA-30`) stays out of Cycle 1 unless explicitly promoted.
 
 ### 8.4 Suggested stack slices for backend refresh
@@ -141,6 +142,7 @@ Optional post-merge checks (expand later):
 
 - `GRA-12`: `docs/adr/ADR-0001-system-of-record-boundaries.md`
 - `GRA-13`: `docs/adr/ADR-0002-jobstate-contract.md`
+- `GRA-37`: `docs/adr/ADR-0003-projection-boundary-and-single-write-cutover.md`
 
 ## 9. Review bottleneck controls
 


### PR DESCRIPTION
## Summary
- Add ADR-0003 to lock projection boundary and single-write cutover policy for backend refresh.
- Document explicit anti-pattern: avoid broad AiiDA-to-Convex model mirroring.
- Clarify ownership for queue target profiles and worker auth token handling.

## Work Item Metadata
- Linear Issue: GRA-37
- Type: Ask
- Size: S
- Queue Policy: Optional
- Stack: Standalone

## Linked Issues
- https://linear.app/grace-----aq/issue/GRA-37/adr-projection-boundary-and-single-write-cutover-policy
- https://github.com/grace-bidos/chem-model-edit/issues/242

## Changes
- Add `docs/adr/ADR-0003-projection-boundary-and-single-write-cutover.md`.
- Update `docs/adr/README.md` ADR index.
- Update `docs/process/linear-stacked-pr-operating-model.md` accepted ADR mapping and cycle note for GRA-37.

## Validation
- [x] Local checks passed
- [x] Added/updated tests where needed

## Temporary Behavior
- [x] None
- [ ] Present (describe clearly below)
- Description:

## Final Behavior
- Backend refresh PRs now have a binding ADR for:
  - thin Convex product projections
  - on-demand AiiDA detail reads
  - single-write cutover policy (no long-lived dual-write)

## Follow-up Issue/PR (if any)
- [x] None
- [ ] Required (link issue/PR)
- Link:

## CodeRabbit Policy
- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ADR defining projection boundaries, single-write cutover policy, and field-level ownership for product-facing read models and execution provenance.
  * Clarified that detailed execution views require on-demand adapter reads; Redis limited to transient caching/leases.
  * Updated process guidance to include the new ADR and verification/rollback criteria for migration PRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
