### PR TITLE
GRA-20: Add FastAPI thin adapter cleanup plan

### DIFF
--- a/docs/process/fastapi-thin-adapter-cleanup-plan.md
+++ b/docs/process/fastapi-thin-adapter-cleanup-plan.md
@@ -1,0 +1,106 @@
+# FastAPI Thin Adapter Cleanup Plan (`GRA-20`)
+
+## Goal
+
+Rescope FastAPI into a thin adapter layer for backend refresh while preserving domain-heavy logic in Python service modules and external systems of record.
+
+This plan is aligned with:
+
+- `docs/adr/ADR-0001-system-of-record-boundaries.md`
+- `docs/adr/ADR-0003-projection-boundary-and-single-write-cutover.md`
+
+## Deliverables Covered
+
+- Route/service cleanup plan
+- Retained responsibilities for Python domain wrappers
+- Deprecated endpoint list (planned, not immediate removal)
+
+## Target Layer Boundaries
+
+FastAPI adapter must keep only:
+
+- authentication/authorization gates
+- request/response schema validation
+- orchestration between application services
+- error/status-code mapping
+- request-scoped logging metadata wiring
+
+FastAPI adapter must not own:
+
+- durable business state semantics
+- queue or lease internals
+- worker token lifecycle internals
+- scientific workflow provenance internals
+
+## Retained Python Responsibilities
+
+The following responsibilities remain in Python service modules and are intentionally not absorbed into route handlers:
+
+- QE input parsing and normalization wrappers:
+  - `apps/api/services/zpe/parse.py`
+  - `apps/api/services/parse.py`
+- ASE/pymatgen conversion and structure operations:
+  - `apps/api/services/structures.py`
+  - `apps/api/services/supercells.py`
+  - `apps/api/services/transplant.py`
+- QE runtime wrappers and execution utilities:
+  - `apps/api/services/zpe/qe.py`
+  - `apps/api/services/zpe/worker.py`
+  - `apps/api/services/zpe/thermo.py`
+- Result/lease/queue orchestration internals (transitional until cutover completes):
+  - `apps/api/services/zpe/result_store.py`
+  - `apps/api/services/zpe/lease.py`
+  - `apps/api/services/zpe/compute_results.py`
+
+## Route/Service Cleanup Plan
+
+### Phase 1: Router Slimming (No Behavior Change)
+
+- Extract per-endpoint application-level orchestration from `apps/api/app/routers/zpe.py` into dedicated application services under `apps/api/services/zpe/`.
+- Keep route handlers focused on auth gates, DTO conversion, and HTTP error mapping.
+- Keep current API contract stable.
+
+### Phase 2: Ownership-Safe Refactor
+
+- Ensure each persisted field has a single durable owner (`Convex` or `AiiDA/Postgres`).
+- Prevent reintroduction of Redis durable ownership semantics.
+- Keep Redis limited to transient lease/transport/cache paths.
+
+### Phase 3: Endpoint Deprecation and Removal
+
+- Mark selected legacy endpoints as deprecated in OpenAPI only after replacement paths are available.
+- Remove deprecated endpoints after migration window and compatibility checks.
+
+## Planned Deprecated Endpoints
+
+These are planned deprecations, not immediate removals.
+
+1. `GET /api/zpe/targets`
+   - Reason: queue target profile reads move to product-facing projection owner.
+   - Replacement direction: Convex-backed projection query.
+   - Earliest removal window: after target read path migration in backend refresh runtime stack.
+
+2. `PUT /api/zpe/targets/{target_id}/active`
+   - Reason: active target selection ownership moves to product-facing projection owner.
+   - Replacement direction: Convex-backed projection mutation.
+   - Earliest removal window: after frontend/BFF migration to replacement mutation.
+
+3. `POST /api/zpe/compute/enroll-tokens`
+4. `POST /api/zpe/compute/servers`
+5. `DELETE /api/zpe/compute/servers/{server_id}`
+   - Reason: worker credential lifecycle should be owned by dedicated auth authority, not route-local Redis semantics.
+   - Replacement direction: dedicated auth/worker enrollment service contract.
+   - Earliest removal window: after token issuance/revocation migration is complete.
+
+6. `GET /api/zpe/admin/ops`
+7. `PATCH /api/zpe/admin/ops`
+   - Reason: transitional emergency controls should move to managed platform flag ownership.
+   - Replacement direction: platform-managed operational control plane.
+   - Earliest removal window: after single-write cutover stabilization period.
+
+## Validation Checklist for `GRA-20` PR Layers
+
+- Route handlers do not contain durable state ownership logic.
+- Route handlers do not implement queue/lease/token internals directly.
+- Service extraction preserves current API responses and status codes.
+- Deprecation targets are documented with migration destination and removal condition.

--- a/docs/process/linear-stacked-pr-operating-model.md
+++ b/docs/process/linear-stacked-pr-operating-model.md
@@ -103,6 +103,7 @@ Optional post-merge checks (expand later):
 5. Review:
    - review in GitHub
    - keep fixes inside same stack branch
+   - for runtime/backend-refresh PRs, include ADR-0001 SoR mapping in PR description (`field/aggregate`, `owner`, `write path`, `read path`)
 6. Merge:
    - merge bottom-up: land the base PR first, then proceed upward through the stack
    - use merge queue where required
@@ -137,12 +138,17 @@ Optional post-merge checks (expand later):
   - `GRA-14` -> `GRA-15` -> `GRA-16` -> `GRA-18` -> `GRA-20`
 - Stack C (migration and operations):
   - `GRA-21` -> `GRA-22` -> `GRA-19` -> `GRA-23` -> `GRA-24` -> `GRA-25`
+  - follow ADR-0003 single-write cutover policy for migration PRs (`GRA-21`, `GRA-22`): no long-lived dual-write phase, rollback behavior documented, and temporary emergency-stop flags must include explicit expiry/removal plan
 
 ### 8.5 Accepted ADRs for backend refresh foundations
 
 - `GRA-12`: `docs/adr/ADR-0001-system-of-record-boundaries.md`
 - `GRA-13`: `docs/adr/ADR-0002-jobstate-contract.md`
 - `GRA-37`: `docs/adr/ADR-0003-projection-boundary-and-single-write-cutover.md`
+
+### 8.6 Active refactor plan artifacts
+
+- `GRA-20`: `docs/process/fastapi-thin-adapter-cleanup-plan.md`
 
 ## 9. Review bottleneck controls
 


### PR DESCRIPTION
## Summary
- Add a concrete cleanup plan for rescoping FastAPI into a thin adapter layer.
- Document retained Python domain responsibilities and route/service separation boundaries.
- Define planned deprecated endpoint list with migration conditions.

## Work Item Metadata
- Linear Issue: GRA-20
- Type: Show
- Size: M
- Queue Policy: Optional
- Stack: Standalone

## Linked Issues
- https://linear.app/grace-----aq/issue/GRA-20/rescope-fastapi-as-thin-python-adapter-layer
- https://github.com/grace-bidos/chem-model-edit/issues/193

## Changes
- Add `docs/process/fastapi-thin-adapter-cleanup-plan.md`.
- Update `docs/process/linear-stacked-pr-operating-model.md`:
  - add active artifact link for GRA-20
  - require ADR-0001 SoR mapping in runtime PR review flow
  - add ADR-0003 single-write cutover reminder for migration stack

## Validation
- [x] Local checks passed
- [x] Added/updated tests where needed

## Temporary Behavior
- [x] None
- [ ] Present (describe clearly below)
- Description:

## Final Behavior
- Backend refresh now has an explicit migration-safe cleanup plan for thin FastAPI adapter refactoring, including deprecation targets and removal conditions.

## Follow-up Issue/PR (if any)
- [x] None
- [ ] Required (link issue/PR)
- Link:

## CodeRabbit Policy
- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)
