### PR TITLE
GRA-24: Persist structure data across API restarts with SQLite store

### DIFF
--- a/apps/api/.env.control.example
+++ b/apps/api/.env.control.example
@@ -3,6 +3,10 @@ ZPE_REDIS_URL=redis://localhost:6379/0
 ZPE_QUEUE_NAME=zpe
 ZPE_COMPUTE_MODE=remote-queue
 ZPE_RESULT_STORE=redis
+# Structure store persistence (default backend is sqlite)
+# STRUCTURE_STORE_BACKEND=sqlite
+# STRUCTURE_STORE_DB_PATH=.just-runtime/structures.sqlite3
+# STRUCTURE_STORE_RESET_ON_START=0
 # Keep admin token only in the control-plane
 ZPE_ADMIN_TOKEN=change-me
 # Optional: enroll token TTL in seconds

--- a/apps/api/tests/test_structures_persistence.py
+++ b/apps/api/tests/test_structures_persistence.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from ase import Atoms as ASEAtoms
+from fastapi.testclient import TestClient
+
+import main
+from services.cif import atoms_to_cif
+from services import structures as structure_service
+from services.structures import SQLiteStructureStore
+
+QE_INPUT = """
+&CONTROL
+  calculation='scf'
+/
+&SYSTEM
+  ibrav=0, nat=2, ntyp=1
+/
+&ELECTRONS
+/
+ATOMIC_SPECIES
+ H 1.0079 H.pbe-rrkjus.UPF
+CELL_PARAMETERS angstrom
+  5.0 0.0 0.0
+  0.0 5.0 0.0
+  0.0 0.0 5.0
+ATOMIC_POSITIONS angstrom
+ H 0.0 0.0 0.0
+ H 0.0 0.0 0.74
+""".strip()
+
+
+def test_sqlite_structure_store_persists_across_reopen(tmp_path: Path) -> None:
+    db_path = tmp_path / "structures.sqlite3"
+    atoms = ASEAtoms(symbols=["H", "H"], positions=[(0.0, 0.0, 0.0), (0.0, 0.0, 0.74)])
+    cif = atoms_to_cif(atoms)
+
+    first = SQLiteStructureStore(db_path, reset_on_start=True)
+    structure_id = first.create(
+        atoms=atoms,
+        source="qe",
+        cif=cif,
+        params=None,
+        raw_input="raw-input",
+    )
+
+    reopened = SQLiteStructureStore(db_path, reset_on_start=False)
+    entry = reopened.get(structure_id)
+
+    assert entry is not None
+    assert entry.source == "qe"
+    assert entry.raw_input == "raw-input"
+    assert len(entry.atoms) == 2
+
+
+def test_structure_api_survives_store_reload(monkeypatch, tmp_path: Path) -> None:
+    db_path = tmp_path / "structures.sqlite3"
+    monkeypatch.setenv("STRUCTURE_STORE_BACKEND", "sqlite")
+    monkeypatch.setenv("STRUCTURE_STORE_DB_PATH", str(db_path))
+    monkeypatch.setenv("STRUCTURE_STORE_RESET_ON_START", "1")
+    structure_service.reload_structure_store()
+
+    try:
+        client = TestClient(main.app)
+        created = client.post("/api/structures", json={"content": QE_INPUT})
+        assert created.status_code == 200
+        structure_id = created.json()["structure_id"]
+
+        monkeypatch.setenv("STRUCTURE_STORE_RESET_ON_START", "0")
+        structure_service.reload_structure_store()
+
+        fetched = client.get(f"/api/structures/{structure_id}")
+        assert fetched.status_code == 200
+        payload = fetched.json()
+        assert payload["raw_input"] == QE_INPUT
+        assert len(payload["structure"]["atoms"]) == 2
+
+        monkeypatch.setenv("STRUCTURE_STORE_RESET_ON_START", "1")
+        structure_service.reload_structure_store()
+
+        missing = client.get(f"/api/structures/{structure_id}")
+        assert missing.status_code == 404
+    finally:
+        monkeypatch.setenv("STRUCTURE_STORE_BACKEND", "memory")
+        monkeypatch.delenv("STRUCTURE_STORE_DB_PATH", raising=False)
+        monkeypatch.delenv("STRUCTURE_STORE_RESET_ON_START", raising=False)
+        structure_service.reload_structure_store()

--- a/docs/process/linear-stacked-pr-operating-model.md
+++ b/docs/process/linear-stacked-pr-operating-model.md
@@ -152,6 +152,7 @@ Optional post-merge checks (expand later):
 - `GRA-20`: `docs/process/fastapi-thin-adapter-cleanup-plan.md`
 - `GRA-21`: `docs/process/redis-worker-cutover-flags.md`
 - `GRA-22`: `docs/process/redis-worker-retirement-plan.md`
+- `GRA-24`: `docs/process/structure-store-persistence.md`
 
 ## 9. Review bottleneck controls
 

--- a/docs/process/structure-store-persistence.md
+++ b/docs/process/structure-store-persistence.md
@@ -1,0 +1,63 @@
+# Structure Store Persistence Guide (`GRA-24`)
+
+This document describes the local durable storage model for structure records
+and the reset/backup procedure for development.
+
+## Overview
+
+`services.structures` now supports a SQLite-backed store so imported structure
+records survive API process restarts.
+
+- backend selector: `STRUCTURE_STORE_BACKEND`
+- supported backends: `sqlite` (default), `memory`
+- SQLite path: `STRUCTURE_STORE_DB_PATH`
+- reset switch: `STRUCTURE_STORE_RESET_ON_START`
+
+Default SQLite path is `<repo>/.just-runtime/structures.sqlite3`.
+
+## Development Defaults
+
+Recommended `.env` values for local restart-survival behavior:
+
+```env
+STRUCTURE_STORE_BACKEND=sqlite
+STRUCTURE_STORE_DB_PATH=.just-runtime/structures.sqlite3
+STRUCTURE_STORE_RESET_ON_START=0
+```
+
+## Intentional Reset Procedure (Dev)
+
+Use one of the following options.
+
+Option A (one-time reset on next start):
+
+```bash
+STRUCTURE_STORE_RESET_ON_START=1 uv run uvicorn apps.api.main:app --reload --port 8000
+```
+
+Option B (manual file delete):
+
+```bash
+rm -f .just-runtime/structures.sqlite3
+```
+
+## Backup Procedure (Dev/Staging)
+
+SQLite copy backup:
+
+```bash
+cp .just-runtime/structures.sqlite3 .just-runtime/structures.sqlite3.bak
+```
+
+Restore:
+
+```bash
+cp .just-runtime/structures.sqlite3.bak .just-runtime/structures.sqlite3
+```
+
+## Notes
+
+- ZPE queue/lease/result paths remain separate concerns and are not changed by
+  this structure-store persistence layer.
+- Tests for restart survival live in
+  `apps/api/tests/test_structures_persistence.py`.


### PR DESCRIPTION
## Summary
- migrate `services.structures` from in-memory-only storage to a SQLite-backed persistent store
- add runtime config switches for structure storage backend/path/reset behavior
- add restart-survival tests for both direct store reopen and API-level store reload
- document dev backup/reset procedure and wire the artifact into the operating model map

## Work Item Metadata
- Linear Issue: GRA-24
- Type: Show
- Size: M
- Queue Policy: Required
- Stack: Standalone

## Linked Issues
- https://linear.app/grace-----aq/issue/GRA-24/persist-structureworkspace-data-across-api-restarts
- https://github.com/grace-bidos/chem-model-edit/issues/215
- https://github.com/grace-bidos/chem-model-edit/issues/176

## Changes
- `apps/api/services/structures.py`
  - introduce `SQLiteStructureStore`
  - keep `InMemoryStructureStore` for explicit fallback/testing
  - add env-driven backend selection (`STRUCTURE_STORE_BACKEND`, `STRUCTURE_STORE_DB_PATH`, `STRUCTURE_STORE_RESET_ON_START`)
  - add `reload_structure_store()` helper for runtime/test reload simulation
- `apps/api/tests/test_structures_persistence.py`
  - add persistence regression tests
- `apps/api/.env.control.example`
  - document structure-store environment knobs
- `docs/process/structure-store-persistence.md`
  - document local backup/reset workflow
- `docs/process/linear-stacked-pr-operating-model.md`
  - register GRA-24 active artifact

## Validation
- [x] Local checks passed
- [x] Added/updated tests where needed
- `uv run --project apps/api pytest`
- `uv run --project apps/api ruff check apps/api`
- `uv run --project apps/api mypy apps/api`
- `pnpm run -s lint:md docs/process/structure-store-persistence.md docs/process/linear-stacked-pr-operating-model.md`
- `pnpm run -s check:md docs/process/structure-store-persistence.md docs/process/linear-stacked-pr-operating-model.md`

## Temporary Behavior
- [x] None
- [ ] Present (describe clearly below)
- Description: N/A

## Final Behavior
- structure records created via `/api/structures` persist across API process restarts by default via SQLite, while keeping explicit local reset controls

## Follow-up Issue/PR (if any)
- [ ] None
- [x] Required (link issue/PR)
- Link: `GRA-25` and later runtime migration items that move remaining transient Redis-owned runtime state toward durable owners

## CodeRabbit Policy
- [x] Required (product/API/auth/worker behavior changed)
- [ ] Optional (process/docs/template/script-only change)
