### PR TITLE
GRA-32: Reduce CodeRabbit review noise while preserving policy checks

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,11 +6,11 @@ reviews:
   commit_status: true
   fail_commit_status: false
   high_level_summary: true
-  changed_files_summary: true
-  collapse_walkthrough: false
+  changed_files_summary: false
+  collapse_walkthrough: true
   sequence_diagrams: false
-  estimate_code_review_effort: true
-  assess_linked_issues: true
+  estimate_code_review_effort: false
+  assess_linked_issues: false
   related_issues: false
   related_prs: false
   suggested_labels: false
@@ -42,7 +42,7 @@ reviews:
       mode: warning
   auto_review:
     enabled: true
-    auto_incremental_review: true
+    auto_incremental_review: false
     auto_pause_after_reviewed_commits: 3
     ignore_title_keywords:
       - "WIP"
@@ -50,4 +50,4 @@ reviews:
       - "NO-CR"
     base_branches:
       - ".*"
-    drafts: true
+    drafts: false


### PR DESCRIPTION
## Summary
- Tune CodeRabbit configuration to reduce low-signal review noise while keeping policy/status gates active.

## Work Item Metadata
- Linear Issue: GRA-32
- Type: Ship
- Size: S
- Queue Policy: Optional
- Stack: Standalone

## Linked Issues
- None

## Changes
- Set `changed_files_summary: false` to reduce repetitive change recap noise.
- Set `collapse_walkthrough: true` to reduce review thread verbosity by default.
- Set `estimate_code_review_effort: false` and `assess_linked_issues: false` to suppress low-value advisory noise.
- Set `auto_incremental_review: false` and `drafts: false` to avoid repeated draft/incremental review churn.
- Preserved policy checks and statuses (`review_status`, `commit_status`, and `pre_merge_checks`).

## Validation
- [x] Local checks passed
- [ ] Added/updated tests where needed
- `pnpm dlx prettier@3.7.4 --check .coderabbit.yaml`

## Temporary Behavior
- [x] None
- [ ] Present (describe clearly below)
- Description:

## Final Behavior
- CodeRabbit remains active for policy enforcement and review status reporting, with reduced non-critical review noise.

## Follow-up Issue/PR (if any)
- [x] None
- [ ] Required (link issue/PR)
- Link:

## CodeRabbit Policy
- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)
