### PR TITLE
feat(gra-18): first BFF aggregation status slice

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,7 +1,8 @@
 import { createApiClient } from '@chem-model/api-client'
 
-import type { ApiRequest } from '@chem-model/api-client'
+import type { ApiRequest, ZPEJobStatus } from '@chem-model/api-client'
 import { requestApi } from '@/server/api'
+import { fetchAggregatedZpeJobStatus } from '@/server/zpe-aggregation'
 
 type TokenProvider = () => Promise<string | null>
 
@@ -63,7 +64,15 @@ export const selectQueueTarget = api.selectQueueTarget
 /** ZPE ジョブを作成する。 */
 export const createZpeJob = api.createZpeJob
 /** ZPE ジョブ状態を ID で取得する。 */
-export const fetchZpeStatus = api.fetchZpeStatus
+export const fetchZpeStatus = async (job_id: string): Promise<ZPEJobStatus> => {
+  const token = (await tokenProvider?.()) ?? null
+  return fetchAggregatedZpeJobStatus({
+    data: {
+      jobId: job_id,
+      token,
+    },
+  })
+}
 /** ZPE ジョブ結果を ID で取得する。 */
 export const fetchZpeResult = api.fetchZpeResult
 /** ZPE ジョブ出力ファイルをダウンロードする。 */

--- a/apps/web/src/server/zpe-aggregation.test.ts
+++ b/apps/web/src/server/zpe-aggregation.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  normalizeAggregatedZpeJobStatus,
+  requireAuthToken,
+} from './zpe-aggregation'
+
+describe('requireAuthToken', () => {
+  it('throws when token is missing', () => {
+    expect(() => requireAuthToken(null)).toThrow('Authentication required')
+  })
+
+  it('returns token when present', () => {
+    expect(requireAuthToken('token-123')).toBe('token-123')
+  })
+})
+
+describe('normalizeAggregatedZpeJobStatus', () => {
+  it('normalizes legacy FastAPI status payloads', () => {
+    const normalized = normalizeAggregatedZpeJobStatus(
+      {
+        status: 'started',
+        detail: 'running',
+        updated_at: '2026-02-15T08:00:00Z',
+      },
+      'job-1',
+    )
+
+    expect(normalized).toEqual({
+      status: 'started',
+      detail: 'running',
+      updated_at: '2026-02-15T08:00:00Z',
+    })
+  })
+
+  it('normalizes Convex-style status payloads', () => {
+    const normalized = normalizeAggregatedZpeJobStatus(
+      {
+        jobId: 'job-2',
+        status: 'finished',
+        detail: null,
+        updatedAt: '2026-02-15T08:01:00Z',
+      },
+      'job-2',
+    )
+
+    expect(normalized).toEqual({
+      status: 'finished',
+      detail: null,
+      updated_at: '2026-02-15T08:01:00Z',
+    })
+  })
+
+  it('falls back to eventTime when updatedAt is missing', () => {
+    const normalized = normalizeAggregatedZpeJobStatus(
+      {
+        jobId: 'job-3',
+        status: 'queued',
+        eventTime: '2026-02-15T08:02:00Z',
+      },
+      'job-3',
+    )
+
+    expect(normalized).toEqual({
+      status: 'queued',
+      detail: null,
+      updated_at: '2026-02-15T08:02:00Z',
+    })
+  })
+
+  it('rejects job id mismatch for Convex-style payloads', () => {
+    expect(() =>
+      normalizeAggregatedZpeJobStatus(
+        {
+          jobId: 'other-job',
+          status: 'queued',
+        },
+        'job-4',
+      ),
+    ).toThrow('Upstream job status payload mismatch')
+  })
+
+  it('rejects unsupported payloads', () => {
+    expect(() =>
+      normalizeAggregatedZpeJobStatus(
+        {
+          status: 'queued',
+          updatedAt: '2026-02-15T08:03:00Z',
+        },
+        'job-5',
+      ),
+    ).toThrow('Unsupported status payload from upstream')
+  })
+})

--- a/apps/web/src/server/zpe-aggregation.ts
+++ b/apps/web/src/server/zpe-aggregation.ts
@@ -1,0 +1,131 @@
+import { createServerFn } from '@tanstack/react-start'
+import { JOB_STATES } from '@chem-model/shared/job-state'
+import type { JobState } from '@chem-model/shared/job-state'
+import type { ZPEJobStatus } from '@chem-model/api-client'
+
+import { requestApiInternal } from '@/server/api'
+
+export type AggregatedZpeJobStatusRequest = {
+  jobId: string
+  token?: string | null
+}
+
+type LegacyZpeJobStatusPayload = {
+  status: JobState
+  detail?: string | null
+  updated_at?: string | null
+}
+
+type ConvexProjectionJobStatusPayload = {
+  jobId: string
+  status: JobState
+  detail?: string | null
+  updatedAt?: string | null
+  eventTime?: string | null
+}
+
+const JOB_STATE_SET = new Set<JobState>(JOB_STATES)
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null
+}
+
+const isStringOrNullish = (value: unknown): value is string | null | undefined => {
+  return value === null || value === undefined || typeof value === 'string'
+}
+
+const isJobState = (value: unknown): value is JobState => {
+  return typeof value === 'string' && JOB_STATE_SET.has(value as JobState)
+}
+
+const isLegacyStatusPayload = (
+  value: unknown,
+): value is LegacyZpeJobStatusPayload => {
+  if (!isRecord(value)) {
+    return false
+  }
+  return (
+    isJobState(value.status) &&
+    isStringOrNullish(value.detail) &&
+    isStringOrNullish(value.updated_at)
+  )
+}
+
+const isConvexProjectionStatusPayload = (
+  value: unknown,
+): value is ConvexProjectionJobStatusPayload => {
+  if (!isRecord(value)) {
+    return false
+  }
+  return (
+    typeof value.jobId === 'string' &&
+    isJobState(value.status) &&
+    isStringOrNullish(value.detail) &&
+    isStringOrNullish(value.updatedAt) &&
+    isStringOrNullish(value.eventTime)
+  )
+}
+
+export const requireAuthToken = (token: string | null | undefined): string => {
+  if (!token) {
+    throw new Error('Authentication required')
+  }
+  return token
+}
+
+export const normalizeAggregatedZpeJobStatus = (
+  payload: unknown,
+  expectedJobId: string,
+): ZPEJobStatus => {
+  const hasConvexMarkers =
+    isRecord(payload) &&
+    ('jobId' in payload || 'updatedAt' in payload || 'eventTime' in payload)
+
+  if (hasConvexMarkers) {
+    if (!isConvexProjectionStatusPayload(payload)) {
+      throw new Error('Unsupported status payload from upstream')
+    }
+    if (payload.jobId !== expectedJobId) {
+      throw new Error('Upstream job status payload mismatch')
+    }
+    return {
+      status: payload.status,
+      detail: payload.detail ?? null,
+      updated_at: payload.updatedAt ?? payload.eventTime ?? null,
+    }
+  }
+
+  if (isLegacyStatusPayload(payload)) {
+    return {
+      status: payload.status,
+      detail: payload.detail ?? null,
+      updated_at: payload.updated_at ?? null,
+    }
+  }
+
+  throw new Error('Unsupported status payload from upstream')
+}
+
+type FetchAggregatedZpeJobStatusFn = ((options: {
+  data: AggregatedZpeJobStatusRequest
+}) => Promise<ZPEJobStatus>) & {
+  url: string
+}
+
+export const fetchAggregatedZpeJobStatus: FetchAggregatedZpeJobStatusFn =
+  createServerFn({
+    method: 'POST',
+  })
+    .inputValidator((data: AggregatedZpeJobStatusRequest) => data)
+    .handler(async ({ data }) => {
+      const token = requireAuthToken(data.token)
+      const safeJobId = encodeURIComponent(data.jobId)
+
+      // TODO(GRA-18): fan-out to Convex projection and AiiDA detail sources.
+      const upstreamPayload = await requestApiInternal<unknown>({
+        path: `/zpe/jobs/${safeJobId}`,
+        token,
+      })
+
+      return normalizeAggregatedZpeJobStatus(upstreamPayload, data.jobId)
+    })

--- a/docs/process/gra-18-bff-aggregation-boundary.md
+++ b/docs/process/gra-18-bff-aggregation-boundary.md
@@ -1,0 +1,98 @@
+# GRA-18 BFF Aggregation Boundary (First Slice)
+
+## Scope
+
+This document defines the first implementation slice for `GRA-18`.
+
+Implemented in this slice:
+
+- one BFF server-function path for job status reads
+- DTO normalization from upstream payloads to a single web DTO
+- auth guard enforcement at the BFF boundary
+
+Out of scope for this slice:
+
+- Convex runtime query integration
+- AiiDA detail endpoint fan-out
+- write-path aggregation
+
+## Ownership Boundary
+
+- `Convex` owns product-facing projection fields (job list/read model metadata).
+- `AiiDA/Postgres` owns execution internals and provenance details.
+- Web BFF server functions own:
+  - auth guard at web boundary,
+  - upstream orchestration (fan-out in later slices),
+  - DTO normalization for stable web-consumer contracts.
+
+## First Path Contract
+
+Server function: `fetchAggregatedZpeJobStatus`
+
+Input contract:
+
+```ts
+{
+  jobId: string
+  token: string | null
+}
+```
+
+Rules:
+
+- `token` is required for this protected path.
+- missing/empty token is rejected before upstream calls.
+
+Output contract (web DTO):
+
+```ts
+{
+  status: 'queued' | 'started' | 'finished' | 'failed'
+  detail: string | null
+  updated_at: string | null
+}
+```
+
+## Upstream DTOs Accepted by Normalizer
+
+Legacy FastAPI status shape:
+
+```ts
+{
+  status: 'queued' | 'started' | 'finished' | 'failed'
+  detail?: string | null
+  updated_at?: string | null
+}
+```
+
+Convex-style projection shape (forward-compatible normalization):
+
+```ts
+{
+  jobId: string
+  status: 'queued' | 'started' | 'finished' | 'failed'
+  detail?: string | null
+  updatedAt?: string | null
+  eventTime?: string | null
+}
+```
+
+Normalization behavior:
+
+- always emit `updated_at` in snake_case for current web client compatibility
+- map `updatedAt` or `eventTime` to `updated_at` for Convex-style payloads
+- reject payloads that do not match either accepted upstream shape
+
+## Error Mapping
+
+BFF path maps/propagates errors with these semantics:
+
+- missing token -> `unauthorized` (`Authentication required`)
+- upstream non-2xx -> pass through API error message from standard backend error payload
+- invalid upstream DTO shape -> internal BFF error (`Unsupported status payload from upstream`)
+
+## TODO Boundaries
+
+- Add Convex read query for projection metadata and merge with AiiDA/adapter status read.
+- Add explicit BFF error type with stable machine-readable code for all normalization failures.
+- Expand contract to include source metadata once UI consumes it.


### PR DESCRIPTION
## Summary
- Ship a minimal, reviewable first slice for `GRA-18` (BFF aggregation refactor).
- Introduce one concrete TanStack Start server-function path for protected ZPE status reads.
- Add DTO normalization for legacy/future payload shapes and boundary documentation.

## Work Item Metadata
- Linear Issue: GRA-18
- Type: Show
- Size: M
- Queue Policy: Required
- Stack: Standalone

## Linked Issues
- GitHub: #209

## Changes
- Added boundary spec doc: `docs/process/gra-18-bff-aggregation-boundary.md`.
- Added `fetchAggregatedZpeJobStatus` in `apps/web/src/server/zpe-aggregation.ts` with auth guard and normalized output shape.
- Extracted `requestApiInternal` in `apps/web/src/server/api.ts` for shared proxy logic.
- Wired `apps/web/src/lib/api.ts` to use the new BFF aggregation path.
- Added tests in `apps/web/src/server/zpe-aggregation.test.ts`.

## Validation
- [x] Local checks passed
- [x] Added/updated tests where needed

## Temporary Behavior
- [x] None
- [ ] Present (describe clearly below)
- Description: N/A

## Final Behavior
- Web status polling now goes through a BFF aggregation entrypoint with auth guard and normalized DTO output.

## Follow-up Issue/PR (if any)
- [ ] None
- [x] Required (link issue/PR)
- Link: Follow-up slices in GRA-18 for Convex fan-out/AiiDA detail merge and typed BFF error envelope.

## CodeRabbit Policy
- [x] Required (product/API/auth/worker behavior changed)
- [ ] Optional (process/docs/template/script-only change)
