### PR TITLE
chore: share pnpm store across worktrees (GRA-53)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-store-dir=.pnpm-store
+store-dir=~/.pnpm-store


### PR DESCRIPTION
## Summary
- switch pnpm store policy from repo-relative `.pnpm-store` to shared user-level `~/.pnpm-store`
- avoid repeated cold installs when creating new git worktrees

## Validation
- `pnpm config get store-dir` returns `~/.pnpm-store`
- install in a fresh verification worktree showed full cache reuse (`reused 1323, downloaded 0`)

Linear Issue: GRA-53
Type: Ship
Size: XS
Queue Policy: Optional
Stack: Standalone

## CodeRabbit Policy
- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package management configuration for local development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->