### PR TITLE
docs: refine AGENTS Linear operation policy (GRA-54)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,12 +43,14 @@ Primary capabilities include parallel structure views, partial structure transpl
 - Do not close capability work by merge-only signal. Verify issue-level acceptance criteria first.
 
 ### Cycle assignment policy
+
 - Put child delivery issues in cycles.
-- Put parent capability issues in cycles by default so cycle throughput includes coordination and integration overhead.
-- Exception: keep a parent issue out of cycle only when it is intentionally long-running across multiple cycles and not an active coordination focus this week.
+- Keep parent capability issues out of cycles by default; use project views to track parent progress.
+- Exception: a parent issue may be put in a cycle only for explicit coordination checkpoints.
 - During cycle calibration phases, it is acceptable to intentionally over-pack current cycle scope to measure realistic weekly throughput.
 
 ### State transition policy
+
 - Child issue lifecycle:
   - `Todo/In Progress/In Review`: active delivery states.
   - `Done`: allowed when PR is merged and child issue acceptance criteria are satisfied.
@@ -58,6 +60,7 @@ Primary capabilities include parallel structure views, partial structure transpl
 - If PR description includes wording like "first slice", "follow-up required", or deferred TODO boundaries, keep the parent open and create missing child issues immediately.
 
 ### Operational issue policy
+
 - Do not create perpetual projects for ongoing environment/tooling chores.
 - Default handling for operational chores: standalone team issue (no project), with `type:*` and `size:*`; assign to cycle only when actively worked.
 - Promote operational work into a project only when it becomes a bounded, multi-issue initiative with explicit completion criteria.


### PR DESCRIPTION
## Summary
- align `AGENTS.md` with current Linear operation/process policy updates
- add mandatory metadata guidance for active issues
- refine cycle/state/operational issue guidance
- clarify pnpm shared store policy text

## Work Item Metadata
- Linear Issue: GRA-54
- Type: Ask
- Size: S
- Queue Policy: Optional
- Stack: Depends on #274

## Linked Issues
- https://linear.app/grace-----aq/issue/GRA-54/refine-agentsmd-with-updated-linear-operation-and-cycle-policy

## Changes
- update Linear operation rules and active-issue metadata requirements
- adjust cycle assignment and state transition guidance
- add an operational issue policy section
- update pnpm store policy wording to `~/.pnpm-store`

## Validation
- [ ] Local checks passed
- [ ] Added/updated tests where needed

## Temporary Behavior
- [x] None
- [ ] Present (describe clearly below)
- Description:

## Final Behavior
- `AGENTS.md` reflects the revised process expectations for Linear planning, issue handling, and cycle coordination.

## Follow-up Issue/PR (if any)
- [x] None
- [ ] Required (link issue/PR)
- Link:

## CodeRabbit Policy
- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)
