### PR TITLE
[GRA-56] Non-markdown style cleanup

### DIFF
--- a/apps/web/src/features/editor-v2/EditorV2Page.tsx
+++ b/apps/web/src/features/editor-v2/EditorV2Page.tsx
@@ -102,16 +102,19 @@ const mergeImportFailures = (
   prev: Array<ImportFailure>,
   failedFiles: Array<ImportFailure>,
 ) => {
-  const merged = new Map(prev.map((item) => [`${item.name}:${item.message}`, item]))
+  const merged = new Map(
+    prev.map((item) => [`${item.name}:${item.message}`, item]),
+  )
   for (const failure of failedFiles) {
     merged.set(`${failure.name}:${failure.message}`, failure)
   }
   return Array.from(merged.values())
 }
 
-const createSupercellOutputFile = (
-  result: { structure_id: string; meta: SupercellBuildMeta },
-): WorkspaceFile => {
+const createSupercellOutputFile = (result: {
+  structure_id: string
+  meta: SupercellBuildMeta
+}): WorkspaceFile => {
   const timestamp = new Date()
     .toISOString()
     .slice(0, 19)

--- a/apps/web/src/features/editor-v2/components/AtomTable.tsx
+++ b/apps/web/src/features/editor-v2/components/AtomTable.tsx
@@ -63,7 +63,9 @@ const buildColumns = (
   }
 
   columns.push(
-    columnHelper.accessor('symbol', { header: 'El' }) as ColumnDef<AtomTableRow>,
+    columnHelper.accessor('symbol', {
+      header: 'El',
+    }) as ColumnDef<AtomTableRow>,
   )
 
   columns.push(
@@ -119,7 +121,10 @@ export function AtomTable({
   showIndex = true,
 }: AtomTableProps) {
   const canSelect = Boolean(onRowClick) && selectionEnabled
-  const columns = useMemo(() => buildColumns(digits, showIndex), [digits, showIndex])
+  const columns = useMemo(
+    () => buildColumns(digits, showIndex),
+    [digits, showIndex],
+  )
 
   const table = useReactTable({
     data: rows,
@@ -130,7 +135,12 @@ export function AtomTable({
   const colSpan = table.getVisibleLeafColumns().length
 
   return (
-    <TableContainer className={cn('h-full rounded border border-slate-100 bg-slate-50 p-2', containerClassName)}>
+    <TableContainer
+      className={cn(
+        'h-full rounded border border-slate-100 bg-slate-50 p-2',
+        containerClassName,
+      )}
+    >
       <Table className="text-xs">
         <TableHeader
           className={cn(stickyHeader && 'sticky top-0 z-10 bg-slate-50')}
@@ -182,14 +192,19 @@ export function AtomTable({
                   {row.getVisibleCells().map((cell) => {
                     const columnId = cell.column.id
                     const cellClass = cn(
-                      columnId === 'index' && 'text-xs font-medium text-slate-500',
+                      columnId === 'index' &&
+                        'text-xs font-medium text-slate-500',
                       columnId === 'symbol' && 'font-semibold text-slate-700',
-                      coordinateColumns.has(columnId) && cn('font-mono', fixedCoordClass),
+                      coordinateColumns.has(columnId) &&
+                        cn('font-mono', fixedCoordClass),
                     )
 
                     return (
                       <TableCell key={cell.id} className={cellClass}>
-                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext(),
+                        )}
                       </TableCell>
                     )
                   })}

--- a/apps/web/src/features/editor-v2/components/FilePanel.tsx
+++ b/apps/web/src/features/editor-v2/components/FilePanel.tsx
@@ -98,7 +98,9 @@ function ParameterTable({ group }: ParameterTableProps) {
         <TableBody>
           {group.entries.map(([key, value]) => (
             <TableRow key={`${group.label}-${key}`}>
-              <TableCell className="font-medium text-slate-500">{key}</TableCell>
+              <TableCell className="font-medium text-slate-500">
+                {key}
+              </TableCell>
               <TableCell className="break-all font-mono text-[11px] text-slate-700">
                 {formatParamValue(value) || '-'}
               </TableCell>

--- a/apps/web/src/features/editor-v2/components/SupercellTool.tsx
+++ b/apps/web/src/features/editor-v2/components/SupercellTool.tsx
@@ -77,7 +77,8 @@ const validateBuildInput = (params: {
   checkOverlap: boolean
   overlapTolerance: string
 }) => {
-  const { baseId, baseHasLattice, grid, checkOverlap, overlapTolerance } = params
+  const { baseId, baseHasLattice, grid, checkOverlap, overlapTolerance } =
+    params
   const gridRows = grid.length
   const gridCols = gridRows > 0 ? grid[0].length : 0
 

--- a/apps/web/src/features/editor-v2/components/ToolPanel.tsx
+++ b/apps/web/src/features/editor-v2/components/ToolPanel.tsx
@@ -1,9 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import {
-  SignInButton,
-  useAuth,
-  useUser,
-} from '@clerk/clerk-react'
+import { SignInButton, useAuth, useUser } from '@clerk/clerk-react'
 import {
   Activity,
   AlertTriangle,
@@ -1560,10 +1556,8 @@ function TransferToolPanel({
         if (applyTokenRef.current !== token) {
           return
         }
-        const {
-          structure: nextStructure,
-          structure_id: structureId,
-        } = await createStructureFromQe(content)
+        const { structure: nextStructure, structure_id: structureId } =
+          await createStructureFromQe(content)
         if (applyTokenRef.current !== token) {
           return
         }
@@ -1600,10 +1594,8 @@ function TransferToolPanel({
       if (applyTokenRef.current !== token) {
         return
       }
-      const {
-        structure: previewStructure,
-        structure_id: structureId,
-      } = await createStructureFromQe(content)
+      const { structure: previewStructure, structure_id: structureId } =
+        await createStructureFromQe(content)
       if (applyTokenRef.current !== token) {
         return
       }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -15,7 +15,7 @@ export function setApiTokenProvider(provider: TokenProvider | null) {
 const request = async <T>(params: ApiRequest): Promise<T> => {
   const token =
     params.token === undefined
-      ? (await tokenProvider?.()) ?? undefined
+      ? ((await tokenProvider?.()) ?? undefined)
       : params.token
   return (await requestApi({ data: { ...params, token } })) as T
 }

--- a/apps/web/src/server/zpe-aggregation.ts
+++ b/apps/web/src/server/zpe-aggregation.ts
@@ -30,7 +30,9 @@ const isRecord = (value: unknown): value is Record<string, unknown> => {
   return typeof value === 'object' && value !== null
 }
 
-const isStringOrNullish = (value: unknown): value is string | null | undefined => {
+const isStringOrNullish = (
+  value: unknown,
+): value is string | null | undefined => {
   return value === null || value === undefined || typeof value === 'string'
 }
 

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -1,4 +1,7 @@
-import { createStartHandler, defaultStreamHandler } from '@tanstack/react-start/server'
+import {
+  createStartHandler,
+  defaultStreamHandler,
+} from '@tanstack/react-start/server'
 
 const handler = createStartHandler(defaultStreamHandler)
 
@@ -22,7 +25,10 @@ type AssetsBinding = {
 }
 
 export default {
-  async fetch(request: Request, env: { ASSETS?: AssetsBinding }): Promise<Response> {
+  async fetch(
+    request: Request,
+    env: { ASSETS?: AssetsBinding },
+  ): Promise<Response> {
     if ((request.method === 'GET' || request.method === 'HEAD') && env.ASSETS) {
       if (isAssetRequest(request)) {
         const assetResponse = await env.ASSETS.fetch(request)


### PR DESCRIPTION
## Summary
- Apply formatter/lint-driven style cleanup to non-Markdown files only
- Keep changes limited to code formatting (no behavior changes)

## Work Item Metadata
- Linear Issue: GRA-56
- Type: Ship
- Size: XS
- Queue Policy: Optional
- Stack: Standalone

## Linked Issues
- GRA-56

## Changes
- Reformat selected `apps/web` TypeScript files after running `just style`
- Preserve functional behavior; only whitespace/line-wrap/import formatting adjustments

## Validation
- [x] Local checks passed
- [ ] Added/updated tests where needed

## Temporary Behavior
- [x] None
- [ ] Present (describe clearly below)
- Description: N/A

## Final Behavior
- Repository style is consistent for touched non-Markdown files
- No runtime behavior change intended

## Follow-up Issue/PR (if any)
- [x] None
- [ ] Required (link issue/PR)
- Link: N/A

## CodeRabbit Policy
- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)
