### PR TITLE
docs(process): align parent-in-cycle policy across AGENTS and ops docs (GRA-57)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Primary capabilities include parallel structure views, partial structure transpl
 
 - Treat Linear Project/Issues as canonical. Do not use GitHub Issues as planning source-of-truth.
 - Keep issue hierarchy to one level only (`Parent -> Child`). Do not create deeper nesting.
-- Mandatory metadata for active issues (`Todo`/`In Progress`/`In Review`): `state`, `cycle`, `type:*`, and `size:*`.
+- Mandatory metadata for active parent and child issues (`Todo`/`In Progress`/`In Review`): `state`, `cycle`, `type:*`, and `size:*`.
 - For delivery work in a project, child issues must have a parent capability issue. Top-level epics/capabilities are the only parentless issues in that project.
 - Use `Backlog` only for parked work outside active execution. When an issue is pulled into the current cycle, move it to `Todo` or `In Progress`.
 - Create follow-up child issues before closing an item when a PR is a partial/first slice.
@@ -51,8 +51,8 @@ Primary capabilities include parallel structure views, partial structure transpl
 ### Cycle assignment policy
 
 - Put child delivery issues in cycles.
-- Keep parent capability issues out of cycles by default; use project views to track parent progress.
-- Exception: a parent issue may be put in a cycle only for explicit coordination checkpoints.
+- Put parent capability issues in cycles by default to reflect current delivery velocity.
+- Exception: keep a parent capability issue out of cycle only when it is intentionally long-running and not active this week.
 - During cycle calibration phases, it is acceptable to intentionally over-pack current cycle scope to measure realistic weekly throughput.
 
 ### State transition policy

--- a/docs/process/coderabbit-parallel-playbook.md
+++ b/docs/process/coderabbit-parallel-playbook.md
@@ -14,7 +14,7 @@ This playbook converts review wait time into delivery time by using stacked PRs 
 2. Start PR-B immediately in another worktree from branch A (stacked).
 3. When PR-A review arrives, fix PR-A first.
 4. Merge PR-A with merge commit.
-5. Rebase/update PR-B onto latest `main` (or onto merged A equivalent).
+5. Restack/sync PR-B onto merged base (prefer `gt sync`; use rebase only if not using Graphite).
 6. Repeat for PR-C, PR-D.
 
 ## Merge Gate (Mandatory)
@@ -22,7 +22,7 @@ This playbook converts review wait time into delivery time by using stacked PRs 
 Do not merge product-impacting PRs when required checks are red or incomplete.
 
 - Product-impacting means API/auth/worker/runtime behavior changes.
-- Required checks are `CI / api`, `CI / web`, and `CI / contract`.
+- Required checks are all branch-protection required checks (including PR policy checks).
 - If CodeRabbit is marked required in the PR template, wait for review output (or explicitly document why unavailable) before merge.
 - If checks are flaky, re-run or fix within the same PR cycle. Do not defer known red checks to `main`.
 
@@ -69,6 +69,6 @@ Optional:
 
 ## PR Template Checklist
 
-- Link child issue and parent epic.
+- Link child issue and parent capability issue (or parent epic when applicable).
 - Declare whether CodeRabbit is required or optional.
 - If temporary behavior exists, document final target and follow-up PR.

--- a/docs/process/gh-template-workflow.md
+++ b/docs/process/gh-template-workflow.md
@@ -8,13 +8,17 @@ Use body files instead of inline shell strings for issue/PR creation to avoid sh
 scripts/gh/create_issue_from_template.sh "Title" /tmp/issue_body.md task
 ```
 
+Use this only when creating an optional GitHub mirror/discussion issue.
+Linear remains planning source-of-truth.
+
 ## Create PR
 
 ```bash
-scripts/gh/create_pr_from_template.sh main <head-branch> "PR title" /tmp/pr_body.md --draft
+scripts/gh/create_pr_from_template.sh <base-branch-or-main> <head-branch> "PR title" /tmp/pr_body.md --draft
 ```
 
 ## Notes
 
 - Keep public issue/PR text in English.
 - Prefer markdown files committed in `specs/` or `/tmp/*.md` when drafting bodies.
+- Ensure PR body includes required metadata fields checked by PR policy (Linear issue, type, size, queue policy, stack, and CodeRabbit policy).

--- a/docs/process/linear-stacked-pr-operating-model.md
+++ b/docs/process/linear-stacked-pr-operating-model.md
@@ -24,12 +24,15 @@ It standardizes how we plan work in Linear, implement with stacked PRs, and pass
 - Project: required for each initiative.
 - Cycle: required for active delivery windows.
 - Issue: required unit of implementation.
+- Fixed implementation hierarchy: `Project -> Parent Capability Issue -> Child Delivery Issue` (one nesting level only).
+- Active parent and child issues are in cycle by default.
+- Exception: a parent capability issue may stay out of cycle only when intentionally long-running and not active this week.
 
 Current default for this phase:
 
 - No roadmap object.
 - Active projects are used as top-level planning containers.
-- Cycle duration is 1 week.
+- Cycle duration is 1 week unless explicitly changed by team settings.
 
 ## 4. Work item taxonomy
 
@@ -103,7 +106,7 @@ Optional post-merge checks (expand later):
 5. Review:
    - review in GitHub
    - keep fixes inside same stack branch
-   - for runtime/backend-refresh PRs, include ADR-0001 SoR mapping in PR description (`field/aggregate`, `owner`, `write path`, `read path`)
+   - include architecture/contract context in PR description when runtime boundaries change
 6. Merge:
    - merge bottom-up: land the base PR first, then proceed upward through the stack
    - use merge queue where required
@@ -111,7 +114,10 @@ Optional post-merge checks (expand later):
    - `gt sync` and restack as needed
    - advance Linear status (`Todo` -> `In Progress` -> `In Review` -> `Done`)
 
-## 8. Backend refresh concrete mapping
+## 8. Backend refresh mapping (historical example)
+
+This section is a historical snapshot from the initial backend-refresh rollout.
+Use it as an example only; current planning source-of-truth is Linear.
 
 ### 8.1 Linear projects
 
@@ -125,10 +131,9 @@ Optional post-merge checks (expand later):
 
 ### 8.3 Cycle loading rule
 
-- Cycle 1 (1 week) includes all backend-refresh execution issues:
-  - `GRA-12` to `GRA-25` under `GRA-10`
+- Cycle 1 (1 week) included active parent capability `GRA-10` and active backend-refresh child issues (`GRA-12` to `GRA-25`).
 - `GRA-37` is a follow-up Ask ADR and is loaded independently when architecture clarification is required.
-- Specialized exploration (`GRA-26` to `GRA-30`) stays out of Cycle 1 unless explicitly promoted.
+- Parent `GRA-11` and specialized exploration (`GRA-26` to `GRA-30`) stayed out of Cycle 1 while not active for that week.
 
 ### 8.4 Suggested stack slices for backend refresh
 

--- a/docs/process/merge-and-cleanup.md
+++ b/docs/process/merge-and-cleanup.md
@@ -1,21 +1,29 @@
 # Merge And Cleanup Workflow
 
 Use this flow to avoid branch deletion failures when a branch is still attached to a worktree.
+Prefer the PR auto-loop for routine operations; use manual steps as fallback.
 
 ## Rules
 
-- Run PR merge from the `main` worktree only.
-- Do not use `--delete-branch` in `gh pr merge`.
-- Cleanup local worktree and branch after merge in a separate step.
+- Prefer `scripts/gh/pr-autoloop.py` with `--merge-when-ready`.
+- If `--delete-branch` fails because branch is attached to a worktree, remove worktree/branch manually afterward.
+- Always sync local `main` immediately after merge.
 
 ## Commands
 
 ```bash
-# 1) Merge the PR from main worktree
+# 1) Preferred: automated review/check/merge loop
+scripts/gh/pr-autoloop.py <PR_NUMBER> --watch --merge-when-ready --merge-method merge
+
+# 2) Optional manual fallback from main worktree
 scripts/git/merge_pr.sh <pr-number-or-url>
 
-# 2) Cleanup worktree and local branch
+# 3) Cleanup worktree and local branch
 scripts/git/cleanup_worktree.sh .worktrees/<name> <branch>
+
+# 4) Sync local main
+git fetch origin --prune
+git -C "$(git rev-parse --show-toplevel)" merge --ff-only origin/main
 ```
 
 ## Dry-run


### PR DESCRIPTION
## Summary
- restore and codify the default policy that parent capability issues are in cycle during active delivery
- align AGENTS.md and referenced process docs to remove contradictory cycle-assignment guidance
- refresh process docs where wording had drifted from current stacked-PR and PR-policy practice

Linear Issue: GRA-57
Type: Ask
Size: S
Queue Policy: Optional
Stack: Standalone

## CodeRabbit Policy
- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)
