### PR TITLE
GRA-58: Codify main-vs-sub-agent operating model and parallel lanes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,11 +107,16 @@ Primary capabilities include parallel structure views, partial structure transpl
   - `git fetch origin --prune`
   - `git -C "$(git rev-parse --show-toplevel)" merge --ff-only origin/main`
 
-### Sub-agent ownership policy
+### Main vs Sub-agent execution model
 
 - Assign sub-agents only child delivery issues, never parent capability issues.
-- Main agent owns parent issue planning, decomposition, and acceptance checks.
-- Sub-agent handoff must include issue id, owned files, out-of-scope boundaries, and reporting language (`English` for inter-agent communication).
+- Main agent owns Linear planning/status/dependency management, parent acceptance checks, and final merge execution.
+- Sub-agents own implementation, research, review-loop handling, and CI fixes for their assigned child issue and owned files.
+- Inter-agent communication (including sub-agent outputs) is English by default.
+- Parallel lane rule: one child issue maps to one lane (`issue -> branch -> worktree -> PR`); sub-agents must not edit outside their lane ownership.
+- Merge-readiness contract for sub-agent handoff: required checks are green (or blocker explicitly documented), review comments are addressed, and remaining risks/conflicts are listed.
+- Conflict handoff rule: if cross-lane conflicts are detected, stop local conflict resolution and hand off to main agent with impacted files, conflict summary, and proposed resolution options.
+- Sub-agents must not merge PRs directly. Main agent performs final merge and post-merge Linear updates.
 
 ## Repository Layout
 

--- a/docs/process/linear-stacked-pr-operating-model.md
+++ b/docs/process/linear-stacked-pr-operating-model.md
@@ -114,7 +114,16 @@ Optional post-merge checks (expand later):
    - `gt sync` and restack as needed
    - advance Linear status (`Todo` -> `In Progress` -> `In Review` -> `Done`)
 
-## 8. Backend refresh mapping (historical example)
+## 8. Main vs sub-agent parallel lanes
+
+- Main agent owns Linear planning/status/dependency management, stack order, and final merge execution.
+- Sub-agents own implementation, research, review-loop handling, and CI fixes inside assigned child-issue lanes only.
+- Inter-agent communication is English by default.
+- Merge-readiness handoff from sub-agent to main must include check status, addressed review feedback, and unresolved risks/conflicts.
+- Sub-agents do not merge PRs directly.
+- If lane conflicts appear, sub-agents hand off conflict context/options to main agent for resolution direction.
+
+## 9. Backend refresh mapping (historical example)
 
 This section is a historical snapshot from the initial backend-refresh rollout.
 Use it as an example only; current planning source-of-truth is Linear.
@@ -160,14 +169,14 @@ Use it as an example only; current planning source-of-truth is Linear.
 - `GRA-22`: `docs/process/redis-worker-retirement-plan.md`
 - `GRA-24`: `docs/process/structure-store-persistence.md`
 
-## 9. Review bottleneck controls
+## 10. Review bottleneck controls
 
 - Keep stack depth typically <= 4 PRs when possible.
 - Keep each PR focused on one issue only.
 - Prefer early draft PR creation to overlap review waiting time with next stacked task.
 - Prioritize reviewing lower-stack PRs first to unblock the whole stack.
 
-## 10. Governance
+## 11. Governance
 
 - Linear is source-of-truth for status and priority.
 - GitHub Issues are optional mirrors or external-facing discussion threads.


### PR DESCRIPTION
## Summary
- codify the main-vs-sub-agent execution model in `AGENTS.md`
- define explicit parallel lane ownership, merge-readiness handoff, and conflict handoff rules
- align `docs/process/linear-stacked-pr-operating-model.md` with the same execution model

## Metadata
Linear Issue: GRA-58
Type: Ask
Size: S
Queue Policy: Optional
Stack: Standalone

## CodeRabbit Policy
- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)

## Validation
- `pnpm dlx markdownlint-cli AGENTS.md docs/process/linear-stacked-pr-operating-model.md`
