### PR TITLE
GRA-59: Harden parallel lane governance and merge-readiness gates

### DIFF
--- a/docs/process/coderabbit-parallel-playbook.md
+++ b/docs/process/coderabbit-parallel-playbook.md
@@ -7,6 +7,11 @@ This playbook converts review wait time into delivery time by using stacked PRs 
 - Every task has a child issue with clear acceptance criteria.
 - Each child issue maps to one small PR.
 - Worktree path is `.worktrees/<branch-name>`.
+- Lane conflict classification and default concurrency:
+  - Low conflict lane (docs/specs/localized tests): up to 3 concurrent child lanes.
+  - Medium conflict lane (same app area, clear file ownership): up to 2 concurrent child lanes.
+  - High conflict lane (shared contracts/schemas/core runtime): 1 active lane; serialize merges.
+- Slot budget: up to 3 planned delivery lanes plus 1 reserved hotfix lane for `main` health recovery.
 
 ## Standard Flow
 
@@ -23,7 +28,9 @@ Do not merge product-impacting PRs when required checks are red or incomplete.
 
 - Product-impacting means API/auth/worker/runtime behavior changes.
 - Required checks are all branch-protection required checks (including PR policy checks).
+- Merge-ready means all of: required checks green, unresolved review threads = 0, and PR head is not `BEHIND` base.
 - If CodeRabbit is marked required in the PR template, wait for review output (or explicitly document why unavailable) before merge.
+- If API contract changes, commit OpenAPI updates and regenerated client artifacts in the same PR before requesting merge.
 - If checks are flaky, re-run or fix within the same PR cycle. Do not defer known red checks to `main`.
 
 ## Start-Next-Task Gate (while waiting)
@@ -34,12 +41,13 @@ Start next task if all are true:
 - Remaining known fixes are low risk and local to current PR.
 - Next task can progress at least 60% without the previous PR merged.
 
-## Rate Limit / Bot Delay Handling
+## CodeRabbit Trigger Policy (Rate-Limit Safe)
 
-- Wait at least 15 minutes before re-requesting review.
+- Trigger once when a PR becomes review-ready.
+- Re-trigger only after substantive new commits; do not re-trigger for metadata/comment-only updates.
+- Keep at least 15 minutes between trigger comments.
 - Batch fixes and push once per review cycle.
-- Use one follow-up comment summarizing all addressed items.
-- If no review appears after 30 minutes, post `@coderabbitai review`.
+- If required review does not appear after 30 minutes, post one retry `@coderabbitai review`; if still blocked, document the blocker in PR.
 
 ## Post-Merge Recovery Protocol
 

--- a/docs/process/linear-stacked-pr-operating-model.md
+++ b/docs/process/linear-stacked-pr-operating-model.md
@@ -86,6 +86,7 @@ Required pre-merge checks (fast):
 - typecheck
 - unit/smoke
 - policy check (type/size labels or equivalent metadata)
+- merge-readiness gate: required checks green, unresolved review threads = 0, and PR head status is not `BEHIND` base
 
 Optional post-merge checks (expand later):
 
@@ -106,6 +107,8 @@ Optional post-merge checks (expand later):
 5. Review:
    - review in GitHub
    - keep fixes inside same stack branch
+   - if API contract changes, commit OpenAPI updates and regenerated client artifacts in the same PR
+   - trigger CodeRabbit once when review-ready; re-trigger only after substantive new commits and at least 15 minutes
    - include architecture/contract context in PR description when runtime boundaries change
 6. Merge:
    - merge bottom-up: land the base PR first, then proceed upward through the stack
@@ -119,7 +122,13 @@ Optional post-merge checks (expand later):
 - Main agent owns Linear planning/status/dependency management, stack order, and final merge execution.
 - Sub-agents own implementation, research, review-loop handling, and CI fixes inside assigned child-issue lanes only.
 - Inter-agent communication is English by default.
-- Merge-readiness handoff from sub-agent to main must include check status, addressed review feedback, and unresolved risks/conflicts.
+- Lane conflict classification and default concurrency:
+  - Low conflict lane (docs/specs/localized tests): up to 3 concurrent child lanes.
+  - Medium conflict lane (same app area, clear file ownership): up to 2 concurrent child lanes.
+  - High conflict lane (shared contracts/schemas/core runtime): 1 active lane; serialize merges.
+- Sub-agent slot budget: up to 3 planned delivery lanes plus 1 reserved hotfix lane for `main` health recovery.
+- Merge-readiness handoff from sub-agent to main requires required checks green, unresolved review threads = 0, and head not `BEHIND` base.
+- Handoff report must also list addressed review feedback and remaining risks/conflicts.
 - Sub-agents do not merge PRs directly.
 - If lane conflicts appear, sub-agents hand off conflict context/options to main agent for resolution direction.
 


### PR DESCRIPTION
## Summary
- Hardened parallel lane governance in `AGENTS.md` and process docs with explicit Low/Medium/High conflict classes and default concurrency guidance.
- Added merge-readiness gate requirements across docs: checks green, unresolved review threads `= 0`, and PR head not `BEHIND` base.
- Added contract-sensitive rule requiring OpenAPI updates plus regenerated client artifacts in the same PR when API contracts change.
- Added sub-agent slot budget guidance with one reserved hotfix lane.
- Added CodeRabbit trigger policy to reduce rate-limit stalls (single trigger on review-ready, retry only after substantive commits and wait interval).

## Validation
- `pnpm dlx markdownlint-cli AGENTS.md docs/process/linear-stacked-pr-operating-model.md docs/process/coderabbit-parallel-playbook.md`
- `pnpm dlx prettier --check AGENTS.md docs/process/linear-stacked-pr-operating-model.md docs/process/coderabbit-parallel-playbook.md`

Linear Issue: GRA-59
Type: Ship
Size: S
Queue Policy: Optional
Stack: Standalone

## CodeRabbit Policy
- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Documentation**
- Updated PR merge-readiness requirements including green checks, resolved review threads, and branch status validation
- Added guidelines for API contract changes requiring specification updates in the same PR
- Refined code review automation trigger policies with improved rate-limiting safeguards
- Introduced lane conflict classification and concurrency management guidelines
- Defined sub-agent slot budget and allocation model for parallel workflows
- Enhanced merge handoff criteria with conflict tracking and risk documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->