### PR TITLE
feat: add lightweight PR/CI helper scripts

### DIFF
--- a/docs/process/gh-template-workflow.md
+++ b/docs/process/gh-template-workflow.md
@@ -2,6 +2,14 @@
 
 Use body files instead of inline shell strings for issue/PR creation to avoid shell expansion bugs.
 
+## Bootstrap PR Body Metadata
+
+```bash
+scripts/gh/bootstrap_pr_body.sh GRA-60 /tmp/pr_body.md --type Ship --size XS --queue Optional --stack Standalone --coderabbit Optional
+```
+
+This writes a template-friendly PR body with all metadata keys validated by `pr-policy`.
+
 ## Create Issue
 
 ```bash
@@ -16,6 +24,36 @@ Linear remains planning source-of-truth.
 ```bash
 scripts/gh/create_pr_from_template.sh <base-branch-or-main> <head-branch> "PR title" /tmp/pr_body.md --draft
 ```
+
+## Check PR Readiness
+
+```bash
+scripts/gh/pr_readiness.py <pr-number-or-url>
+```
+
+The summary includes check status counts, unresolved review thread count, and
+`mergeStateStatus` (including a `BEHIND` action hint).
+
+## Optional: Tail Failed CI Logs
+
+```bash
+scripts/gh/ci_log_tail.sh <pr-number-or-url> --lines 200
+```
+
+Or target an explicit workflow run:
+
+```bash
+scripts/gh/ci_log_tail.sh --run-id <run-id> --lines 120
+```
+
+## Regenerate API Contract Artifacts
+
+```bash
+scripts/api/regenerate_contract.sh
+```
+
+This exports `openapi.json`, regenerates `packages/api-client/src/generated/schema.ts`,
+and prints a focused `git diff` hint for review.
 
 ## Notes
 

--- a/docs/process/merge-and-cleanup.md
+++ b/docs/process/merge-and-cleanup.md
@@ -12,6 +12,9 @@ Prefer the PR auto-loop for routine operations; use manual steps as fallback.
 ## Commands
 
 ```bash
+# 0) Optional one-shot readiness summary
+scripts/gh/pr_readiness.py <PR_NUMBER_OR_URL>
+
 # 1) Preferred: automated review/check/merge loop
 scripts/gh/pr-autoloop.py <PR_NUMBER> --watch --merge-when-ready --merge-method merge
 
@@ -24,6 +27,12 @@ scripts/git/cleanup_worktree.sh .worktrees/<name> <branch>
 # 4) Sync local main
 git fetch origin --prune
 git -C "$(git rev-parse --show-toplevel)" merge --ff-only origin/main
+```
+
+If checks are failing and you need quick context, tail failed-step logs:
+
+```bash
+scripts/gh/ci_log_tail.sh <PR_NUMBER_OR_URL> --lines 200
 ```
 
 ## Dry-run

--- a/scripts/api/regenerate_contract.sh
+++ b/scripts/api/regenerate_contract.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+usage: scripts/api/regenerate_contract.sh
+
+Exports FastAPI OpenAPI schema and regenerates the TS API client artifacts.
+Then prints focused diff hints for review.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+echo "[1/2] Exporting OpenAPI schema"
+PYTHONPATH=apps/api uv run --project apps/api python apps/api/scripts/export_openapi.py
+
+echo "[2/2] Regenerating API client"
+pnpm -C packages/api-client run generate
+
+tracked_files=(
+  "packages/api-client/openapi/openapi.json"
+  "packages/api-client/src/generated/schema.ts"
+)
+
+echo
+echo "Diff hint:"
+echo "  git diff -- ${tracked_files[*]}"
+echo
+
+if git diff --quiet -- "${tracked_files[@]}"; then
+  echo "No contract changes detected in generated artifacts."
+else
+  echo "Generated artifacts changed. Review and commit them in the same PR."
+  git status --short -- "${tracked_files[@]}"
+fi

--- a/scripts/gh/README.md
+++ b/scripts/gh/README.md
@@ -1,5 +1,27 @@
 # GitHub Helper Scripts
 
+## `bootstrap_pr_body.sh`
+
+Generate a PR body stub with required metadata fields and CodeRabbit policy selection.
+
+Examples:
+
+```bash
+scripts/gh/bootstrap_pr_body.sh GRA-60 /tmp/pr_body.md --type Ship --size XS --queue Optional --stack Standalone --coderabbit Optional
+scripts/gh/create_pr_from_template.sh main feature/gra-60-pr-ci-helper-scripts "feat: add PR/CI helper scripts" /tmp/pr_body.md
+```
+
+## `pr_readiness.py`
+
+One-shot PR readiness summary for merge checks, unresolved review threads, and branch-behind state.
+
+Examples:
+
+```bash
+scripts/gh/pr_readiness.py 123
+scripts/gh/pr_readiness.py https://github.com/<owner>/<repo>/pull/123
+```
+
 ## `pr-autoloop.py`
 
 Watch a PR, report readiness blockers, and optionally merge when ready.
@@ -15,4 +37,15 @@ scripts/gh/pr-autoloop.py 123 --watch --merge-when-ready --merge-method merge
 
 # Watch with timeout and resolve only outdated threads
 scripts/gh/pr-autoloop.py 123 --watch --max-wait 3600 --resolve-outdated-threads
+```
+
+## `ci_log_tail.sh`
+
+Tail failed-step logs from a workflow run.
+
+Examples:
+
+```bash
+scripts/gh/ci_log_tail.sh 123 --lines 200
+scripts/gh/ci_log_tail.sh --run-id 123456789 --lines 80
 ```

--- a/scripts/gh/bootstrap_pr_body.sh
+++ b/scripts/gh/bootstrap_pr_body.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+usage: scripts/gh/bootstrap_pr_body.sh <LINEAR-ISSUE> <OUTPUT-MD> [options]
+
+Options:
+  --type <Ask|Show|Ship>            Default: Ship
+  --size <XS|S|M|L>                 Default: S
+  --queue <Required|Optional>       Default: Optional
+  --stack <Standalone|Base|Depends on #N>
+                                    Default: Standalone
+  --coderabbit <Required|Optional>  Default: Optional
+  --force                           Overwrite output file if it exists
+
+Example:
+  scripts/gh/bootstrap_pr_body.sh GRA-60 /tmp/pr_body.md --type Ship --size XS --queue Optional --stack Standalone --coderabbit Optional
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -lt 2 ]]; then
+  usage >&2
+  exit 1
+fi
+
+linear_issue="$1"
+output_file="$2"
+shift 2
+
+type_value="Ship"
+size_value="S"
+queue_policy="Optional"
+stack_value="Standalone"
+coderabbit_policy="Optional"
+force_write="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --type)
+      type_value="${2:-}"
+      shift 2
+      ;;
+    --size)
+      size_value="${2:-}"
+      shift 2
+      ;;
+    --queue)
+      queue_policy="${2:-}"
+      shift 2
+      ;;
+    --stack)
+      stack_value="${2:-}"
+      shift 2
+      ;;
+    --coderabbit)
+      coderabbit_policy="${2:-}"
+      shift 2
+      ;;
+    --force)
+      force_write="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! "$linear_issue" =~ ^[A-Z]+-[0-9]+$ ]]; then
+  echo "error: LINEAR-ISSUE must look like KEY-123 (received: $linear_issue)" >&2
+  exit 1
+fi
+
+case "$type_value" in
+  Ask|Show|Ship) ;;
+  *)
+    echo "error: --type must be Ask, Show, or Ship" >&2
+    exit 1
+    ;;
+esac
+
+case "$size_value" in
+  XS|S|M|L) ;;
+  *)
+    echo "error: --size must be XS, S, M, or L" >&2
+    exit 1
+    ;;
+esac
+
+case "$queue_policy" in
+  Required|Optional) ;;
+  *)
+    echo "error: --queue must be Required or Optional" >&2
+    exit 1
+    ;;
+esac
+
+case "$coderabbit_policy" in
+  Required|Optional) ;;
+  *)
+    echo "error: --coderabbit must be Required or Optional" >&2
+    exit 1
+    ;;
+esac
+
+if [[ "$stack_value" != "Standalone" && "$stack_value" != "Base" && ! "$stack_value" =~ ^Depends\ on\ \#[0-9]+$ ]]; then
+  echo "error: --stack must be Standalone, Base, or 'Depends on #<PR>'" >&2
+  exit 1
+fi
+
+if [[ -e "$output_file" && "$force_write" != "true" ]]; then
+  echo "error: output file already exists: $output_file (use --force to overwrite)" >&2
+  exit 1
+fi
+
+required_checked=" "
+optional_checked=" "
+if [[ "$coderabbit_policy" == "Required" ]]; then
+  required_checked="x"
+else
+  optional_checked="x"
+fi
+
+mkdir -p "$(dirname "$output_file")"
+
+cat > "$output_file" <<EOF2
+# Summary
+
+- TODO
+
+## Work Item Metadata
+
+- Linear Issue: $linear_issue
+- Type: $type_value
+- Size: $size_value
+- Queue Policy: $queue_policy
+- Stack: $stack_value
+
+## Linked Issues
+
+- None
+
+## Changes
+
+- TODO
+
+## Validation
+
+- [ ] Local checks passed
+- [ ] Added/updated tests where needed
+
+## Temporary Behavior
+
+- [x] None
+- [ ] Present (describe clearly below)
+- Description:
+
+## Final Behavior
+
+- TODO
+
+## Follow-up Issue/PR (if any)
+
+- [x] None
+- [ ] Required (link issue/PR)
+- Link:
+
+## CodeRabbit Policy
+
+- [$required_checked] Required (product/API/auth/worker behavior changed)
+- [$optional_checked] Optional (process/docs/template/script-only change)
+EOF2
+
+echo "wrote $output_file"

--- a/scripts/gh/ci_log_tail.sh
+++ b/scripts/gh/ci_log_tail.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+usage:
+  scripts/gh/ci_log_tail.sh <PR_NUMBER_OR_URL> [--lines N]
+  scripts/gh/ci_log_tail.sh --run-id <RUN_ID> [--lines N]
+
+Tail failed-step logs from a workflow run.
+If PR is provided, the latest non-success run on that PR head branch is selected.
+USAGE
+}
+
+lines=120
+run_id=""
+pr_ref=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --run-id)
+      run_id="${2:-}"
+      shift 2
+      ;;
+    --lines)
+      lines="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      if [[ -n "$pr_ref" ]]; then
+        echo "error: unexpected argument: $1" >&2
+        usage >&2
+        exit 1
+      fi
+      pr_ref="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$run_id" && -z "$pr_ref" ]]; then
+  usage >&2
+  exit 1
+fi
+
+if [[ -n "$run_id" && ! "$run_id" =~ ^[0-9]+$ ]]; then
+  echo "error: --run-id must be numeric" >&2
+  exit 1
+fi
+
+if [[ ! "$lines" =~ ^[0-9]+$ ]]; then
+  echo "error: --lines must be numeric" >&2
+  exit 1
+fi
+
+if [[ -z "$run_id" ]]; then
+  head_branch="$(gh pr view "$pr_ref" --json headRefName --jq .headRefName)"
+  run_id="$(gh run list --branch "$head_branch" --limit 30 --json databaseId,status,conclusion --jq '
+    map(select((.status != "completed") or (.conclusion != "success")))
+    | .[0].databaseId // ""
+  ')"
+
+  if [[ -z "$run_id" || "$run_id" == "null" ]]; then
+    echo "No non-success workflow run found for branch: $head_branch" >&2
+    exit 1
+  fi
+fi
+
+echo "Showing failed-step logs for run id: $run_id (last $lines lines)"
+gh run view "$run_id" --log-failed | tail -n "$lines"

--- a/scripts/gh/pr_readiness.py
+++ b/scripts/gh/pr_readiness.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Summarize PR readiness (checks, unresolved review threads, merge state)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+from typing import Any
+
+
+def run_gh(args: list[str]) -> str:
+    proc = subprocess.run(
+        ["gh", *args],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if proc.returncode != 0:
+        cmd = "gh " + " ".join(shlex.quote(arg) for arg in args)
+        raise RuntimeError(f"command failed ({proc.returncode}): {cmd}\n{proc.stderr.strip()}")
+    return proc.stdout
+
+
+def parse_pr_number(value: str) -> int:
+    if value.isdigit():
+        return int(value)
+    if "/pull/" in value:
+        tail = value.rsplit("/pull/", 1)[1].strip("/")
+        if tail.isdigit():
+            return int(tail)
+    raise ValueError(f"invalid PR identifier: {value}")
+
+
+def get_repo_owner_name() -> tuple[str, str]:
+    out = run_gh(["repo", "view", "--json", "nameWithOwner"])
+    payload = json.loads(out)
+    owner, repo = payload["nameWithOwner"].split("/", 1)
+    return owner, repo
+
+
+def get_pr(pr_number: int) -> dict[str, Any]:
+    fields = [
+        "number",
+        "title",
+        "url",
+        "state",
+        "isDraft",
+        "mergeStateStatus",
+        "headRefName",
+        "baseRefName",
+        "statusCheckRollup",
+    ]
+    out = run_gh(["pr", "view", str(pr_number), "--json", ",".join(fields)])
+    return json.loads(out)
+
+
+def get_unresolved_thread_count(pr_number: int) -> int:
+    owner, repo = get_repo_owner_name()
+    query = """
+query($owner:String!, $repo:String!, $num:Int!, $after:String) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$num) {
+      reviewThreads(first:100, after:$after) {
+        nodes {
+          isResolved
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+""".strip()
+
+    unresolved = 0
+    cursor: str | None = None
+
+    while True:
+        args = [
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"repo={repo}",
+            "-F",
+            f"num={pr_number}",
+        ]
+        if cursor:
+            args.extend(["-F", f"after={cursor}"])
+        else:
+            args.extend(["-F", "after="])
+
+        out = run_gh(args)
+        payload = json.loads(out)
+        review_threads = payload["data"]["repository"]["pullRequest"]["reviewThreads"]
+        for node in review_threads.get("nodes", []):
+            if not node.get("isResolved", False):
+                unresolved += 1
+
+        page_info = review_threads.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        cursor = page_info.get("endCursor")
+        if not cursor:
+            break
+
+    return unresolved
+
+
+def classify_checks(rollup: list[dict[str, Any]]) -> tuple[list[str], list[str]]:
+    pending: list[str] = []
+    failing: list[str] = []
+
+    for item in rollup:
+        item_type = item.get("__typename")
+        name = item.get("name") or item.get("context") or "(unknown)"
+        if item_type == "CheckRun":
+            status = item.get("status", "")
+            conclusion = item.get("conclusion", "")
+            if status != "COMPLETED":
+                pending.append(name)
+                continue
+            if conclusion in {"SUCCESS", "NEUTRAL", "SKIPPED"}:
+                continue
+            failing.append(name)
+            continue
+
+        if item_type == "StatusContext":
+            state = item.get("state", "")
+            if state == "SUCCESS":
+                continue
+            if state in {"PENDING", "EXPECTED"}:
+                pending.append(name)
+                continue
+            failing.append(name)
+
+    return pending, failing
+
+
+def is_ready(pr: dict[str, Any], unresolved_count: int, pending: list[str], failing: list[str]) -> bool:
+    return (
+        pr.get("state") == "OPEN"
+        and not pr.get("isDraft", False)
+        and pr.get("mergeStateStatus") == "CLEAN"
+        and unresolved_count == 0
+        and len(pending) == 0
+        and len(failing) == 0
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Summarize PR readiness for CI/review flow")
+    parser.add_argument("pr", help="PR number or PR URL")
+    args = parser.parse_args()
+
+    try:
+        pr_number = parse_pr_number(args.pr)
+        pr = get_pr(pr_number)
+        unresolved_count = get_unresolved_thread_count(pr_number)
+        pending_checks, failing_checks = classify_checks(pr.get("statusCheckRollup") or [])
+    except Exception as exc:  # noqa: BLE001
+        print(str(exc), file=sys.stderr)
+        return 3
+
+    print(f"PR #{pr['number']}: {pr['title']}")
+    print(f"URL: {pr['url']}")
+    print(
+        "State:"
+        f" {pr.get('state')}"
+        f", Draft: {pr.get('isDraft', False)}"
+        f", mergeStateStatus: {pr.get('mergeStateStatus')}"
+        f", Branch: {pr.get('headRefName')} -> {pr.get('baseRefName')}"
+    )
+    print(
+        "Checks:"
+        f" pending={len(pending_checks)}"
+        f", failing={len(failing_checks)}"
+        f", unresolved_review_threads={unresolved_count}"
+    )
+
+    if failing_checks:
+        print("Failing checks:")
+        for name in failing_checks:
+            print(f"- {name}")
+
+    if pending_checks:
+        print("Pending checks:")
+        for name in pending_checks:
+            print(f"- {name}")
+
+    merge_state = pr.get("mergeStateStatus")
+    if merge_state == "BEHIND":
+        print(
+            "Action: branch is behind base. Rebase/merge base into head, then push and re-run checks."
+        )
+
+    if pr.get("state") == "MERGED":
+        print("Result: already merged")
+        return 0
+
+    if pr.get("state") == "CLOSED":
+        print("Result: closed without merge")
+        return 1
+
+    if is_ready(pr, unresolved_count, pending_checks, failing_checks):
+        print("Result: merge-ready")
+        return 0
+
+    print("Result: not ready")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
# Summary

- Add lightweight PR/CI helper scripts for metadata bootstrap, readiness checks, and failed-log tailing.
- Add API contract regeneration helper for OpenAPI export + client generation with diff hints.
- Document usage in process docs and `scripts/gh/README.md`.

## Work Item Metadata

- Linear Issue: GRA-60
- Type: Ship
- Size: S
- Queue Policy: Optional
- Stack: Standalone

## Linked Issues

- None

## Changes

- Added `scripts/gh/bootstrap_pr_body.sh` to generate a PR-body stub aligned with CI `pr-policy` metadata checks.
- Added `scripts/gh/pr_readiness.py` to summarize checks, unresolved review threads, and `mergeStateStatus` (including `BEHIND` action hint).
- Added optional `scripts/gh/ci_log_tail.sh` to tail failed-step logs from latest non-success run (or explicit run id).
- Added `scripts/api/regenerate_contract.sh` to export OpenAPI, regenerate API client types, and print focused diff guidance.
- Updated process docs with copy-paste usage examples.

## Validation

- [x] Local checks passed
- [ ] Added/updated tests where needed

## Temporary Behavior

- [x] None
- [ ] Present (describe clearly below)
- Description:

## Final Behavior

- Developers can bootstrap policy-compliant PR metadata quickly, check readiness in one command, inspect failing CI logs faster, and regenerate API contract artifacts consistently.

## Follow-up Issue/PR (if any)

- [x] None
- [ ] Required (link issue/PR)
- Link:

## CodeRabbit Policy

- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)
