### PR TITLE
Operations/process hardening: lane ownership, inventory, and worktree preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ Primary capabilities include parallel structure views, partial structure transpl
 
 - Before implementation in a new worktree, verify tool availability: `node`, `corepack`, `pnpm`, and `uv`.
 - Minimum preflight checks:
-  - `command -v node corepack pnpm uv`
+  - `for tool in node corepack pnpm uv; do command -v "$tool" >/dev/null || { echo "missing: $tool"; exit 1; }; done`
   - `node -v`
   - `pnpm -v`
   - `uv --version`

--- a/docs/process/coderabbit-parallel-playbook.md
+++ b/docs/process/coderabbit-parallel-playbook.md
@@ -14,7 +14,7 @@ This playbook converts review wait time into delivery time by using stacked PRs 
   - High conflict lane (shared contracts/schemas/core runtime): 1 active lane; serialize merges.
 - Slot budget: up to 3 planned delivery lanes plus 1 reserved hotfix lane for `main` health recovery.
 - Main agent coordinates and merges; it does not run continuous PR/CI polling for every lane.
-- Before lane start, run worktree preflight: `command -v node corepack pnpm uv`, `node -v`, `pnpm -v`, `uv --version`.
+- Before lane start, run worktree preflight: `for tool in node corepack pnpm uv; do command -v "$tool" >/dev/null || { echo "missing: $tool"; exit 1; }; done`, `node -v`, `pnpm -v`, `uv --version`.
 
 ## Standard Flow
 

--- a/docs/process/linear-stacked-pr-operating-model.md
+++ b/docs/process/linear-stacked-pr-operating-model.md
@@ -139,7 +139,7 @@ Optional post-merge checks (expand later):
 ### 8.1 Worktree preflight before lane start
 
 - Before coding in a new lane worktree, verify toolchain readiness: `node`, `corepack`, `pnpm`, `uv`.
-- Required preflight commands: `command -v node corepack pnpm uv`, `node -v`, `pnpm -v`, `uv --version`.
+- Required preflight commands: `for tool in node corepack pnpm uv; do command -v "$tool" >/dev/null || { echo "missing: $tool"; exit 1; }; done`, `node -v`, `pnpm -v`, `uv --version`.
 - If missing tools are detected, remediate first (`corepack enable`, `corepack prepare pnpm@10.27.0 --activate`, install `uv`), then run dependency setup (`pnpm install`, `uv sync` in `apps/api`).
 - Do not start PR auto-loop or CI/watch until preflight is green.
 

--- a/docs/process/merge-and-cleanup.md
+++ b/docs/process/merge-and-cleanup.md
@@ -8,7 +8,7 @@ Prefer the PR auto-loop for routine operations; use manual steps as fallback.
 - Prefer `scripts/gh/pr-autoloop.py` with `--merge-when-ready`.
 - Lane owner (sub-agent) runs the watch loop and CI/review handling for that lane.
 - Main agent should not continuously poll PR/CI for all lanes; it executes milestone-based checks and final merge.
-- In a new worktree, run preflight checks before watch mode: `command -v node corepack pnpm uv`, `node -v`, `pnpm -v`, `uv --version`.
+- In a new worktree, run preflight checks before watch mode: `for tool in node corepack pnpm uv; do command -v "$tool" >/dev/null || { echo "missing: $tool"; exit 1; }; done`, `node -v`, `pnpm -v`, `uv --version`.
 - If `--delete-branch` fails because branch is attached to a worktree, remove worktree/branch manually afterward.
 - Always sync local `main` immediately after merge.
 - On merge/reassignment/cancel, close lane explicitly: post final status, clean worktree/branch, and free slot inventory.


### PR DESCRIPTION
## Summary
- codify main-agent orchestration focus vs lane-owned PR/CI watch responsibilities
- add sub-agent inventory and stale-session close rules
- add worktree preflight checks/remediation for node/corepack/pnpm/uv tool availability

Linear Issue: GRA-51
Type: Ship
Size: S
Queue Policy: Optional
Stack: Standalone

## CodeRabbit Policy
- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)
