### PR TITLE
Clarify user-facing status report style in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ Primary capabilities include parallel structure views, partial structure transpl
 - Public artifacts (GitHub PR/Issue/comments) must be written in English.
 - Inter-agent communication (main agent <-> sub-agents, and sub-agent outputs) must be in English by default.
 - Even when the initiating prompt is in Japanese, sub-agents should answer in English unless explicitly requested otherwise for a specific task.
+- In user-facing status reports, mention task/issue titles first and use identifiers only as supplemental context (for example: `Implement tenant_id propagation (GRA-44)`).
+- Avoid overusing numbered lists in user-facing reports. Prefer short prose or compact bullets unless strict sequencing is required.
 
 ## Mandatory Working Rules
 


### PR DESCRIPTION
## Summary
- add explicit rule to mention task/issue titles first in user-facing status reports
- add explicit rule to avoid overusing numbered lists in user-facing reports

## Why
Align reporting style with readability goals and reduce identifier-first updates that are hard to scan.

## Scope
- docs-only (`AGENTS.md`)

## Validation
- manual review of markdown rendering and wording consistency

## Related
- Linear: GRA-78

Linear Issue: GRA-78
Type: Ship
Size: XS
Queue Policy: Optional
Stack: Standalone

## CodeRabbit Policy
- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)
