### PR TITLE
GRA-75: Enforce ProjectionUpdate monotonicity and dedup in Convex

### DIFF
--- a/convex/projectionStateMachine.test.js
+++ b/convex/projectionStateMachine.test.js
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import {
+  INVALID_PROJECTION_TRANSITION,
+  ProjectionTransitionError,
+  applyProjectionUpdate,
+  createEmptyProjectionAggregate,
+} from './projectionStateMachine'
+
+describe('ProjectionUpdate monotonicity and dedup', () => {
+  it('applies monotonic transitions in order', () => {
+    const aggregate = createEmptyProjectionAggregate()
+
+    const queued = applyProjectionUpdate(aggregate, {
+      projection_event_id: 'evt-1',
+      tenant_id: 'tenant-1',
+      workspace_id: 'ws-1',
+      job_id: 'job-1',
+      submission_id: 'sub-1',
+      projection_state: 'queued',
+    })
+
+    const running = applyProjectionUpdate(aggregate, {
+      projection_event_id: 'evt-2',
+      tenant_id: 'tenant-1',
+      workspace_id: 'ws-1',
+      job_id: 'job-1',
+      submission_id: 'sub-1',
+      projection_state: 'running',
+    })
+
+    const succeeded = applyProjectionUpdate(aggregate, {
+      projection_event_id: 'evt-3',
+      tenant_id: 'tenant-1',
+      workspace_id: 'ws-1',
+      job_id: 'job-1',
+      submission_id: 'sub-1',
+      projection_state: 'succeeded',
+    })
+
+    expect(queued).toEqual({
+      applied: true,
+      idempotent: false,
+      projection_state: 'queued',
+    })
+    expect(running).toEqual({
+      applied: true,
+      idempotent: false,
+      projection_state: 'running',
+    })
+    expect(succeeded).toEqual({
+      applied: true,
+      idempotent: false,
+      projection_state: 'succeeded',
+    })
+  })
+
+  it('treats duplicate projection_event_id as idempotent no-op', () => {
+    const aggregate = createEmptyProjectionAggregate()
+
+    const first = applyProjectionUpdate(aggregate, {
+      projection_event_id: 'evt-replay',
+      tenant_id: 'tenant-1',
+      workspace_id: 'ws-1',
+      job_id: 'job-1',
+      submission_id: 'sub-1',
+      projection_state: 'running',
+    })
+
+    const replay = applyProjectionUpdate(aggregate, {
+      projection_event_id: 'evt-replay',
+      tenant_id: 'tenant-1',
+      workspace_id: 'ws-1',
+      job_id: 'job-1',
+      submission_id: 'sub-1',
+      projection_state: 'failed',
+    })
+
+    expect(first).toEqual({
+      applied: true,
+      idempotent: false,
+      projection_state: 'running',
+    })
+    expect(replay).toEqual({
+      applied: false,
+      idempotent: true,
+      projection_state: 'running',
+    })
+  })
+
+  it('rejects non-monotonic transitions with stable error semantics', () => {
+    const aggregate = createEmptyProjectionAggregate()
+
+    applyProjectionUpdate(aggregate, {
+      projection_event_id: 'evt-10',
+      tenant_id: 'tenant-1',
+      workspace_id: 'ws-1',
+      job_id: 'job-1',
+      submission_id: 'sub-1',
+      projection_state: 'succeeded',
+    })
+
+    let thrown
+    try {
+      applyProjectionUpdate(aggregate, {
+        projection_event_id: 'evt-11',
+        tenant_id: 'tenant-1',
+        workspace_id: 'ws-1',
+        job_id: 'job-1',
+        submission_id: 'sub-1',
+        projection_state: 'running',
+      })
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(ProjectionTransitionError)
+    expect(thrown.code).toBe(INVALID_PROJECTION_TRANSITION)
+    expect(thrown.status).toBe(409)
+    expect(thrown.previous_state).toBe('succeeded')
+    expect(thrown.next_state).toBe('running')
+    expect(thrown.message).toBe('invalid projection transition: succeeded -> running')
+  })
+})

--- a/convex/projectionStateMachine.ts
+++ b/convex/projectionStateMachine.ts
@@ -1,0 +1,133 @@
+export const PROJECTION_STATES = ['queued', 'running', 'succeeded', 'failed'] as const
+
+export type ProjectionState = (typeof PROJECTION_STATES)[number]
+
+export interface ProjectionUpdateInput {
+  projection_event_id: string
+  tenant_id: string
+  workspace_id: string
+  job_id: string
+  submission_id: string
+  projection_state: ProjectionState
+}
+
+export interface ProjectionRecord {
+  target_key: string
+  projection_state: ProjectionState
+}
+
+export interface ProjectionAggregate {
+  projections_by_target: Map<string, ProjectionRecord>
+  seen_projection_event_ids: Set<string>
+}
+
+export interface ApplyProjectionUpdateResult {
+  applied: boolean
+  idempotent: boolean
+  projection_state: ProjectionState
+}
+
+export const INVALID_PROJECTION_TRANSITION =
+  'invalid_projection_transition' as const
+
+const PROJECTION_STATE_ORDER: Record<ProjectionState, number> = {
+  queued: 0,
+  running: 1,
+  succeeded: 2,
+  failed: 2,
+}
+
+const TERMINAL_PROJECTION_STATES = new Set<ProjectionState>([
+  'succeeded',
+  'failed',
+])
+
+export class ProjectionTransitionError extends Error {
+  readonly code = INVALID_PROJECTION_TRANSITION
+  readonly status = 409
+
+  constructor(
+    readonly previous_state: ProjectionState,
+    readonly next_state: ProjectionState,
+  ) {
+    super(
+      `invalid projection transition: ${previous_state} -> ${next_state}`,
+    )
+    this.name = 'ProjectionTransitionError'
+  }
+}
+
+export const buildProjectionTargetKey = (
+  input: Pick<
+    ProjectionUpdateInput,
+    'tenant_id' | 'workspace_id' | 'job_id' | 'submission_id'
+  >,
+): string => {
+  return [
+    input.tenant_id,
+    input.workspace_id,
+    input.job_id,
+    input.submission_id,
+  ].join('::')
+}
+
+export const isMonotonicProjectionTransition = (
+  previous: ProjectionState | null | undefined,
+  next: ProjectionState,
+): boolean => {
+  if (previous == null) return true
+  if (previous === next) return true
+  if (TERMINAL_PROJECTION_STATES.has(previous)) return false
+
+  return PROJECTION_STATE_ORDER[next] >= PROJECTION_STATE_ORDER[previous]
+}
+
+export const assertMonotonicProjectionTransition = (
+  previous: ProjectionState | null | undefined,
+  next: ProjectionState,
+): void => {
+  if (previous == null) return
+  if (isMonotonicProjectionTransition(previous, next)) return
+
+  throw new ProjectionTransitionError(previous, next)
+}
+
+export const createEmptyProjectionAggregate = (): ProjectionAggregate => {
+  return {
+    projections_by_target: new Map<string, ProjectionRecord>(),
+    seen_projection_event_ids: new Set<string>(),
+  }
+}
+
+export const applyProjectionUpdate = (
+  aggregate: ProjectionAggregate,
+  update: ProjectionUpdateInput,
+): ApplyProjectionUpdateResult => {
+  if (aggregate.seen_projection_event_ids.has(update.projection_event_id)) {
+    const targetKey = buildProjectionTargetKey(update)
+    const current = aggregate.projections_by_target.get(targetKey)
+    return {
+      applied: false,
+      idempotent: true,
+      projection_state: current?.projection_state ?? update.projection_state,
+    }
+  }
+
+  const targetKey = buildProjectionTargetKey(update)
+  const current = aggregate.projections_by_target.get(targetKey)
+  const previousState = current?.projection_state ?? null
+
+  assertMonotonicProjectionTransition(previousState, update.projection_state)
+
+  aggregate.projections_by_target.set(targetKey, {
+    target_key: targetKey,
+    projection_state: update.projection_state,
+  })
+  aggregate.seen_projection_event_ids.add(update.projection_event_id)
+
+  return {
+    applied: true,
+    idempotent: false,
+    projection_state: update.projection_state,
+  }
+}

--- a/convex/projectionUpdates.ts
+++ b/convex/projectionUpdates.ts
@@ -1,0 +1,130 @@
+import { mutation } from './_generated/server'
+import { ConvexError, v } from 'convex/values'
+import {
+  INVALID_PROJECTION_TRANSITION,
+  ProjectionTransitionError,
+  assertMonotonicProjectionTransition,
+} from './projectionStateMachine'
+
+const projectionStateValidator = v.union(
+  v.literal('queued'),
+  v.literal('running'),
+  v.literal('succeeded'),
+  v.literal('failed'),
+)
+
+export const applyProjectionUpdate = mutation({
+  args: {
+    projection_event_id: v.string(),
+    tenant_id: v.string(),
+    workspace_id: v.string(),
+    job_id: v.string(),
+    submission_id: v.string(),
+    projection_state: projectionStateValidator,
+    source_execution_state: v.union(
+      v.literal('accepted'),
+      v.literal('running'),
+      v.literal('completed'),
+      v.literal('failed'),
+    ),
+    occurred_at: v.string(),
+    trace_id: v.string(),
+    display_message: v.optional(v.string()),
+    result_ref: v.optional(
+      v.object({
+        output_uri: v.string(),
+        summary: v.optional(v.string()),
+      }),
+    ),
+    failure: v.optional(
+      v.object({
+        code: v.string(),
+        message: v.string(),
+      }),
+    ),
+  },
+  handler: async (ctx, args) => {
+    const existingReceipt = await (ctx.db
+      .query('projection_event_receipts') as any)
+      .withIndex('by_projection_event_id', (q: any) =>
+        q.eq('projection_event_id', args.projection_event_id),
+      )
+      .first()
+
+    if (existingReceipt) {
+      return {
+        ok: true,
+        applied: false,
+        idempotent: true,
+        projection_state: args.projection_state,
+      } as const
+    }
+
+    const existingProjection = await (ctx.db.query('projection_states') as any)
+      .withIndex('by_target', (q: any) =>
+        q
+          .eq('tenant_id', args.tenant_id)
+          .eq('workspace_id', args.workspace_id)
+          .eq('job_id', args.job_id)
+          .eq('submission_id', args.submission_id),
+      )
+      .first()
+
+    const previousState = existingProjection?.projection_state ?? null
+
+    try {
+      assertMonotonicProjectionTransition(previousState, args.projection_state)
+    } catch (error) {
+      if (error instanceof ProjectionTransitionError) {
+        throw new ConvexError({
+          code: INVALID_PROJECTION_TRANSITION,
+          status: 409,
+          message: error.message,
+          previous_projection_state: error.previous_state,
+          next_projection_state: error.next_state,
+        })
+      }
+      throw error
+    }
+
+    const nowIso = new Date().toISOString()
+    const projectionDocument = {
+      tenant_id: args.tenant_id,
+      workspace_id: args.workspace_id,
+      job_id: args.job_id,
+      submission_id: args.submission_id,
+      projection_state: args.projection_state,
+      source_execution_state: args.source_execution_state,
+      occurred_at: args.occurred_at,
+      trace_id: args.trace_id,
+      display_message: args.display_message,
+      result_ref: args.result_ref,
+      failure: args.failure,
+      last_projection_event_id: args.projection_event_id,
+      updated_at: nowIso,
+    }
+
+    if (existingProjection) {
+      await ctx.db.patch(existingProjection._id, projectionDocument)
+    } else {
+      await ctx.db.insert('projection_states', projectionDocument)
+    }
+
+    await ctx.db.insert('projection_event_receipts', {
+      projection_event_id: args.projection_event_id,
+      tenant_id: args.tenant_id,
+      workspace_id: args.workspace_id,
+      job_id: args.job_id,
+      submission_id: args.submission_id,
+      projection_state: args.projection_state,
+      recorded_at: nowIso,
+    })
+
+    return {
+      ok: true,
+      applied: true,
+      idempotent: false,
+      projection_state: args.projection_state,
+    } as const
+  },
+})

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,0 +1,57 @@
+import { defineSchema, defineTable } from 'convex/server'
+import { v } from 'convex/values'
+
+const projectionStateValidator = v.union(
+  v.literal('queued'),
+  v.literal('running'),
+  v.literal('succeeded'),
+  v.literal('failed'),
+)
+
+export default defineSchema({
+  projection_states: defineTable({
+    tenant_id: v.string(),
+    workspace_id: v.string(),
+    job_id: v.string(),
+    submission_id: v.string(),
+    projection_state: projectionStateValidator,
+    source_execution_state: v.union(
+      v.literal('accepted'),
+      v.literal('running'),
+      v.literal('completed'),
+      v.literal('failed'),
+    ),
+    occurred_at: v.string(),
+    trace_id: v.string(),
+    display_message: v.optional(v.string()),
+    result_ref: v.optional(
+      v.object({
+        output_uri: v.string(),
+        summary: v.optional(v.string()),
+      }),
+    ),
+    failure: v.optional(
+      v.object({
+        code: v.string(),
+        message: v.string(),
+      }),
+    ),
+    last_projection_event_id: v.string(),
+    updated_at: v.string(),
+  }).index('by_target', [
+    'tenant_id',
+    'workspace_id',
+    'job_id',
+    'submission_id',
+  ]),
+
+  projection_event_receipts: defineTable({
+    projection_event_id: v.string(),
+    tenant_id: v.string(),
+    workspace_id: v.string(),
+    job_id: v.string(),
+    submission_id: v.string(),
+    projection_state: projectionStateValidator,
+    recorded_at: v.string(),
+  }).index('by_projection_event_id', ['projection_event_id']),
+})


### PR DESCRIPTION
# Summary

- Implement ProjectionUpdate monotonic transition and dedup guarantees in Convex runtime path.

## Work Item Metadata

- Linear Issue: GRA-75
- Type: Show
- Size: S
- Queue Policy: Required
- Stack: Standalone

## Linked Issues

- None

## Changes

- Added Convex-side projection state machine to enforce monotonic transitions.
- Added deterministic transition rejection semantics for non-monotonic updates.
- Implemented duplicate `projection_event_id` replay as idempotent no-op.
- Added schema/index support for projection state and event receipts.
- Added transition/replay unit tests.

## Validation

- [x] Local checks passed
- [x] Added/updated tests where needed

## Temporary Behavior

- [x] None
- [ ] Present (describe clearly below)
- Description:

## Final Behavior

- Convex projection mutations now enforce contract-level ordering and replay semantics.

## Follow-up Issue/PR (if any)

- [x] None
- [ ] Required (link issue/PR)
- Link:

## CodeRabbit Policy

- [x] Required (product/API/auth/worker behavior changed)
- [ ] Optional (process/docs/template/script-only change)
