### PR TITLE
Implement VM baseline provisioning for Slurm/AiiDA validation on WSL (GRA-86)

### DIFF
--- a/docs/process/vm-baseline-provisioning-from-wsl.md
+++ b/docs/process/vm-baseline-provisioning-from-wsl.md
@@ -1,0 +1,97 @@
+# VM Baseline Provisioning from WSL (GRA-86)
+
+This runbook provides a reproducible and low-risk baseline workflow for Hyper-V VM provisioning from WSL.
+
+Scope:
+- Create a baseline VM from WSL (safe defaults, idempotent bring-up)
+- Capture a known-good snapshot
+- Reset the VM back to that snapshot
+
+## Files
+
+- Entry point: `scripts/vm-baseline.sh`
+- WSL wrapper: `ops/vm/vm-baseline.sh`
+- Hyper-V implementation: `ops/vm/hyperv-baseline.ps1`
+
+## Preflight
+
+Run from repository root in WSL:
+
+```bash
+for tool in node corepack pnpm uv; do command -v "$tool" >/dev/null || { echo "missing: $tool"; exit 1; }; done
+node -v
+pnpm -v
+uv --version
+./scripts/vm-baseline.sh -Action preflight
+```
+
+The Hyper-V switch defaults to `Default Switch`. Override it with `-SwitchName` when needed.
+
+## Minimal Bring-up (safe defaults)
+
+```bash
+./scripts/vm-baseline.sh -Action bringup
+```
+
+Default values:
+- `VmName=chem-baseline`
+- `SwitchName=Default Switch`
+- `VhdPath=C:\HyperV\chem-baseline\chem-baseline.vhdx`
+- `MemoryGb=8`
+- `CpuCount=4`
+- `DiskGb=120`
+
+Notes:
+- Bring-up is idempotent. If VM already exists, creation is skipped.
+- VM is not auto-started unless `-StartVm` is passed.
+
+## First-boot bring-up with installer ISO
+
+```bash
+./scripts/vm-baseline.sh -Action bringup \
+  -IsoPath 'C:\ISO\ubuntu-24.04-live-server-amd64.iso' \
+  -StartVm
+```
+
+## Baseline Snapshot Workflow
+
+After initial OS setup and hardening in the VM, save the baseline checkpoint:
+
+```bash
+./scripts/vm-baseline.sh -Action snapshot -SnapshotName baseline
+```
+
+If you need to replace an existing baseline snapshot:
+
+```bash
+./scripts/vm-baseline.sh -Action snapshot -SnapshotName baseline -ReplaceSnapshot
+```
+
+## Reset Workflow
+
+Reset VM state to the baseline snapshot:
+
+```bash
+./scripts/vm-baseline.sh -Action reset -SnapshotName baseline
+```
+
+Reset and start immediately:
+
+```bash
+./scripts/vm-baseline.sh -Action reset -SnapshotName baseline -StartVm
+```
+
+## Status
+
+```bash
+./scripts/vm-baseline.sh -Action status
+```
+
+Use status before and after reset to confirm snapshot-driven reproducibility.
+
+## Safety Defaults
+
+- No destructive action on bring-up for existing VMs.
+- Snapshot replacement requires explicit `-ReplaceSnapshot`.
+- Reset requires an existing snapshot name.
+- VM auto-start is opt-in (`-StartVm`).

--- a/ops/vm/hyperv-baseline.ps1
+++ b/ops/vm/hyperv-baseline.ps1
@@ -1,0 +1,183 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateSet('preflight', 'bringup', 'snapshot', 'reset', 'status')]
+  [string]$Action,
+
+  [string]$VmName = 'chem-baseline',
+  [string]$SwitchName = 'Default Switch',
+  [string]$VhdPath = 'C:\\HyperV\\chem-baseline\\chem-baseline.vhdx',
+  [string]$IsoPath = '',
+  [string]$SnapshotName = 'baseline',
+  [int]$MemoryGb = 8,
+  [int]$CpuCount = 4,
+  [int]$DiskGb = 120,
+  [switch]$StartVm,
+  [switch]$ReplaceSnapshot
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Assert-Cmdlet {
+  param([string]$Name)
+
+  if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+    throw "Missing required Hyper-V cmdlet: $Name"
+  }
+}
+
+function Invoke-Preflight {
+  Assert-Cmdlet -Name 'Get-VM'
+  Assert-Cmdlet -Name 'Get-VMSwitch'
+  Assert-Cmdlet -Name 'Get-VHD'
+
+  if (-not (Get-VMSwitch -Name $SwitchName -ErrorAction SilentlyContinue)) {
+    throw "VMSwitch '$SwitchName' was not found. Create it in Hyper-V Manager or pass -SwitchName."
+  }
+
+  Write-Host "Preflight OK for VM '$VmName' with switch '$SwitchName'."
+}
+
+function Invoke-Bringup {
+  Invoke-Preflight
+
+  if ($MemoryGb -le 0 -or $CpuCount -le 0 -or $DiskGb -le 0) {
+    throw 'MemoryGb, CpuCount, and DiskGb must be positive integers.'
+  }
+
+  $existingVm = Get-VM -Name $VmName -ErrorAction SilentlyContinue
+  if ($existingVm) {
+    Write-Host "VM '$VmName' already exists. Skipping create."
+  }
+  else {
+    $vhdDir = Split-Path -Path $VhdPath -Parent
+    if (-not (Test-Path -LiteralPath $vhdDir)) {
+      New-Item -ItemType Directory -Path $vhdDir -Force | Out-Null
+    }
+
+    if (-not (Test-Path -LiteralPath $VhdPath)) {
+      New-VHD -Path $VhdPath -Dynamic -SizeBytes (${DiskGb}GB) | Out-Null
+      Write-Host "Created VHD: $VhdPath"
+    }
+    else {
+      Write-Host "Using existing VHD: $VhdPath"
+    }
+
+    New-VM `
+      -Name $VmName `
+      -Generation 2 `
+      -MemoryStartupBytes (${MemoryGb}GB) `
+      -VHDPath $VhdPath `
+      -SwitchName $SwitchName | Out-Null
+
+    Set-VMProcessor -VMName $VmName -Count $CpuCount
+    Set-VM -Name $VmName -AutomaticStartAction Nothing -AutomaticStopAction ShutDown -CheckpointType Standard | Out-Null
+
+    Write-Host "Created VM '$VmName' (memory=${MemoryGb}GB, cpu=$CpuCount, disk=${DiskGb}GB)."
+  }
+
+  if ($IsoPath -ne '') {
+    if (-not (Test-Path -LiteralPath $IsoPath)) {
+      throw "ISO not found: $IsoPath"
+    }
+
+    $dvdDrive = Get-VMDvdDrive -VMName $VmName -ErrorAction SilentlyContinue
+    if ($dvdDrive) {
+      Set-VMDvdDrive -VMName $VmName -Path $IsoPath | Out-Null
+    }
+    else {
+      Add-VMDvdDrive -VMName $VmName -Path $IsoPath | Out-Null
+    }
+
+    Write-Host "Attached ISO: $IsoPath"
+  }
+
+  if ($StartVm) {
+    Start-VM -Name $VmName | Out-Null
+    Write-Host "Started VM '$VmName'."
+  }
+
+  Invoke-Status
+}
+
+function Invoke-Snapshot {
+  Invoke-Preflight
+
+  $vm = Get-VM -Name $VmName -ErrorAction SilentlyContinue
+  if (-not $vm) {
+    throw "VM '$VmName' not found. Run bringup first."
+  }
+
+  $existing = Get-VMSnapshot -VMName $VmName -Name $SnapshotName -ErrorAction SilentlyContinue
+  if ($existing) {
+    if ($ReplaceSnapshot) {
+      Remove-VMSnapshot -VMName $VmName -Name $SnapshotName -Confirm:$false
+      Write-Host "Removed existing snapshot '$SnapshotName'."
+    }
+    else {
+      Write-Host "Snapshot '$SnapshotName' already exists. Use -ReplaceSnapshot to refresh it."
+      return
+    }
+  }
+
+  Checkpoint-VM -Name $VmName -SnapshotName $SnapshotName | Out-Null
+  Write-Host "Created snapshot '$SnapshotName' for '$VmName'."
+}
+
+function Invoke-Reset {
+  Invoke-Preflight
+
+  $vm = Get-VM -Name $VmName -ErrorAction SilentlyContinue
+  if (-not $vm) {
+    throw "VM '$VmName' not found."
+  }
+
+  $snapshot = Get-VMSnapshot -VMName $VmName -Name $SnapshotName -ErrorAction SilentlyContinue
+  if (-not $snapshot) {
+    throw "Snapshot '$SnapshotName' not found for VM '$VmName'."
+  }
+
+  if ($vm.State -ne 'Off') {
+    Stop-VM -Name $VmName -TurnOff -Force
+  }
+
+  Restore-VMSnapshot -VMName $VmName -Name $SnapshotName -Confirm:$false
+  Write-Host "Restored '$VmName' to snapshot '$SnapshotName'."
+
+  if ($StartVm) {
+    Start-VM -Name $VmName | Out-Null
+    Write-Host "Started VM '$VmName'."
+  }
+
+  Invoke-Status
+}
+
+function Invoke-Status {
+  $vm = Get-VM -Name $VmName -ErrorAction SilentlyContinue
+  if (-not $vm) {
+    Write-Host "VM '$VmName' not found."
+    return
+  }
+
+  $snapshots = Get-VMSnapshot -VMName $VmName -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name
+  if (-not $snapshots) {
+    $snapshotDisplay = '(none)'
+  }
+  else {
+    $snapshotDisplay = ($snapshots -join ', ')
+  }
+
+  Write-Host "VM: $($vm.Name)"
+  Write-Host "State: $($vm.State)"
+  Write-Host "CPU: $($vm.ProcessorCount)"
+  Write-Host "MemoryStartupBytes: $($vm.MemoryStartup)"
+  Write-Host "Snapshots: $snapshotDisplay"
+}
+
+switch ($Action) {
+  'preflight' { Invoke-Preflight }
+  'bringup' { Invoke-Bringup }
+  'snapshot' { Invoke-Snapshot }
+  'reset' { Invoke-Reset }
+  'status' { Invoke-Status }
+  default { throw "Unsupported action: $Action" }
+}

--- a/ops/vm/vm-baseline.sh
+++ b/ops/vm/vm-baseline.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PS_SCRIPT_WIN="$(wslpath -w "$SCRIPT_DIR/hyperv-baseline.ps1")"
+
+if ! command -v powershell.exe >/dev/null 2>&1; then
+  echo "powershell.exe not found. Run this script from WSL on Windows." >&2
+  exit 1
+fi
+
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$PS_SCRIPT_WIN" "$@"

--- a/scripts/vm-baseline.sh
+++ b/scripts/vm-baseline.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec "$ROOT_DIR/ops/vm/vm-baseline.sh" "$@"


### PR DESCRIPTION
Linear Issue: GRA-86
Type: Show
Size: S
Queue Policy: Optional
Stack: Standalone

## Summary
- add WSL to VM baseline provisioning scripts
- add Hyper-V oriented helper and wrapper entrypoint
- add runbook for preflight/create/status/snapshot/reset workflow

## Validation
- tool preflight (node/corepack/pnpm/uv)
- shell syntax checks for scripts
- wrapper preflight/status commands

## CodeRabbit Policy
- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)
