### PR TITLE
Remove Redis/RQ business ownership from runtime hot paths (GRA-77)

### DIFF
--- a/apps/api/services/zpe/backends.py
+++ b/apps/api/services/zpe/backends.py
@@ -10,7 +10,6 @@ from app.schemas.zpe import ZPEJobRequest
 from services.structures import get_structure
 from .io import format_freqs_csv, format_summary
 from .job_meta import get_job_meta_store
-from .job_owner import get_job_owner_store
 from .parse import (
     ensure_mobile_indices,
     extract_fixed_indices,
@@ -197,8 +196,6 @@ def submit_job(
             resolved_queue_name=resolved_queue_name,
         ),
     )
-    owner_store = get_job_owner_store()
-    owner_store.set_owner(job_id, user_id, tenant_id)
     slurm_resolution_meta = {}
     if resolution is not None:
         slurm_resolution_meta = {

--- a/apps/api/services/zpe/compute_results.py
+++ b/apps/api/services/zpe/compute_results.py
@@ -16,7 +16,6 @@ from services.convex_event_relay import (
 )
 
 from .job_meta import get_job_meta_store
-from .job_owner import get_job_owner_store
 from .job_state import JobState, can_transition, coerce_job_state
 from .queue import get_redis_connection
 from .settings import get_zpe_settings
@@ -109,8 +108,8 @@ def _dispatch_runtime_state_transition(
         relay_token=settings.convex_relay_token,
         timeout_seconds=settings.convex_relay_timeout_seconds,
     )
-    owner_id = get_job_owner_store().get_owner(job_id)
     meta = get_job_meta_store().get_meta(job_id)
+    owner_id = _coerce_non_empty(meta.get("user_id"))
     project_id = _coerce_non_empty(meta.get("project_id")) or _coerce_non_empty(
         meta.get("queue_name")
     )

--- a/apps/api/services/zpe/job_meta.py
+++ b/apps/api/services/zpe/job_meta.py
@@ -37,5 +37,5 @@ class JobMetaStore:
             return {}
 
 
-def get_job_meta_store() -> JobMetaStore:
-    return JobMetaStore()
+def get_job_meta_store(*, redis: Optional[Redis] = None) -> JobMetaStore:
+    return JobMetaStore(redis=redis)

--- a/apps/api/services/zpe/settings.py
+++ b/apps/api/services/zpe/settings.py
@@ -41,6 +41,7 @@ class ZPESettings(BaseSettings):
     cutover_submission_route: Literal["redis-worker", "next-gen"] = "redis-worker"
     cutover_result_read_source: Literal["redis", "projection"] = "redis"
     legacy_worker_endpoints_enabled: bool = True
+    ops_flag_ttl_seconds: int = 3600
 
     pw_command: str = "pw.x"
     pw_path: Optional[str] = None

--- a/docs/contracts/redis-rq-retirement-boundary.md
+++ b/docs/contracts/redis-rq-retirement-boundary.md
@@ -89,3 +89,11 @@ For remaining transitional Redis keys/logs, include at minimum:
 - Are ownership and contract docs updated for changed runtime behavior?
 
 If any answer is yes to the first two, PR must be rejected unless this document is explicitly updated with a temporary expiry-bound exception.
+
+## Implemented status (`GRA-77`, February 16, 2026)
+
+- [x] Runtime owner checks no longer require dedicated Redis owner keys in hot paths.
+- [x] Runtime relay owner derivation reads execution metadata (`user_id`) instead of Redis owner keys.
+- [x] Admin ops flags in Redis are bounded by TTL (`ZPE_OPS_FLAG_TTL_SECONDS`).
+- [x] Legacy Redis owner key reads are compatibility fallback only (non-authoritative, pre-cutover support).
+- [x] Product SoR (`Convex`) and Execution SoR (`management node stack`) remain the authoritative boundary model for runtime semantics.


### PR DESCRIPTION
## Summary
- remove owner-key writes from submit hot path
- prefer job_meta as source of truth and keep owner key as compatibility fallback only
- bound operational ops-flag keys with TTL and update retirement-boundary checklist

## Validation
- UV_LINK_MODE=copy uv run --project apps/api pytest apps/api/tests/test_zpe_api.py apps/api/tests/test_zpe_compute_results.py
- UV_LINK_MODE=copy uv run --project apps/api mypy apps/api/services/zpe/backends.py apps/api/services/zpe/compute_results.py apps/api/services/zpe/job_meta.py apps/api/services/zpe/job_owner.py apps/api/services/zpe/ops_flags.py apps/api/services/zpe/settings.py

Linear Issue: GRA-77
Type: Show
Size: M
Queue Policy: Required
Stack: Standalone

## CodeRabbit Policy
- [x] Required (product/API/auth/worker behavior changed)
- [ ] Optional (process/docs/template/script-only change)