### PR TITLE
fix: unblock Hyper-V baseline parser for VM validation

### DIFF
--- a/ops/vm/hyperv-baseline.ps1
+++ b/ops/vm/hyperv-baseline.ps1
@@ -55,7 +55,7 @@ function Invoke-Bringup {
     }
 
     if (-not (Test-Path -LiteralPath $VhdPath)) {
-      New-VHD -Path $VhdPath -Dynamic -SizeBytes (${DiskGb}GB) | Out-Null
+      New-VHD -Path $VhdPath -Dynamic -SizeBytes ($DiskGb * 1GB) | Out-Null
       Write-Host "Created VHD: $VhdPath"
     }
     else {
@@ -65,7 +65,7 @@ function Invoke-Bringup {
     New-VM `
       -Name $VmName `
       -Generation 2 `
-      -MemoryStartupBytes (${MemoryGb}GB) `
+      -MemoryStartupBytes ($MemoryGb * 1GB) `
       -VHDPath $VhdPath `
       -SwitchName $SwitchName | Out-Null
 


### PR DESCRIPTION
## Summary
- replace invalid PowerShell size literals in `ops/vm/hyperv-baseline.ps1`
- use arithmetic with the built-in `1GB` unit for both disk and memory byte arguments
- keep behavior unchanged while making the script parse correctly

## Why
The previous `${DiskGb}GB` / `${MemoryGb}GB` forms trigger a PowerShell parser error before cmdlet checks run. This blocked VM validation flows.

## Validation
- ran `scripts/vm-baseline.sh preflight`
- confirmed parser error is gone
- command now proceeds to expected environment failure in this host: `Missing required Hyper-V cmdlet: Get-VM`

Linear Issue: GRA-92
Type: Show
Size: XS
Queue Policy: Required
Stack: Standalone

## CodeRabbit Policy
- [x] Required (product/API/auth/worker behavior changed)
- [ ] Optional (process/docs/template/script-only change)
