### PR TITLE
GRA-98 canary: verify trusted self-hosted routing

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,0 +1,2 @@
+
+<!-- self-hosted canary: safe no-op line -->


### PR DESCRIPTION
## Summary
- canary PR to verify trusted self-hosted routing after enabling `CI_SELF_HOSTED_TRUSTED_ROUTING=true`
- no functional code change (README no-op line only)

## Testing
- workflow routing verification only

Linear Issue: GRA-98
Type: Ship
Size: XS
Queue Policy: Optional
Stack: Standalone

## CodeRabbit Policy
- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)

Refs GRA-98


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Minor documentation updates with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->