### PR TITLE
GRA-99 Add local runner pool scaling script

### DIFF
--- a/docs/process/self-hosted-jit-vm-operator-checklist.md
+++ b/docs/process/self-hosted-jit-vm-operator-checklist.md
@@ -63,6 +63,39 @@ cd /opt/actions-runner
 sudo ./bin/installdependencies.sh
 ```
 
+## 4.1) Repair or bootstrap base runner registration (idempotent)
+
+Use this when a long-lived local runner directory exists but registration was deleted
+or became invalid.
+
+Dry-run first:
+
+```bash
+scripts/runner/bootstrap_local_runner_registration.sh \
+  --owner grace-bidos \
+  --repo chem-model-edit \
+  --runner-home /opt/actions-runner \
+  --labels "self-hosted,linux,x64,chem-trusted-pr" \
+  --dry-run
+```
+
+Apply:
+
+```bash
+scripts/runner/bootstrap_local_runner_registration.sh \
+  --owner grace-bidos \
+  --repo chem-model-edit \
+  --runner-home /opt/actions-runner \
+  --labels "self-hosted,linux,x64,chem-trusted-pr"
+```
+
+Behavior summary:
+
+- checks local `.runner` and GitHub runner inventory by name
+- if missing/invalid, fetches a fresh registration token and runs `config.sh --unattended`
+- reinstalls and starts `svc.sh` systemd service
+- keeps existing work folder and runner name defaults unless explicitly overridden
+
 ## 5) Tear-down guarantees
 
 - Enforce `1 VM = 1 Job`.
@@ -76,33 +109,6 @@ After one successful dry run:
 - set `CI_SELF_HOSTED_TRUSTED_ROUTING=true`
 - open a trusted PR and verify route job selects self-hosted label target
 
-## 6.1) Scale local runner count quickly
-
-Use this helper to converge local runner instances to a target count:
-
-```bash
-scripts/runner/scale_local_runner_pool.sh \
-  --repo grace-bidos/chem-model-edit \
-  --target 2
-```
-
-Increase parallelism:
-
-```bash
-scripts/runner/scale_local_runner_pool.sh \
-  --repo grace-bidos/chem-model-edit \
-  --target 4
-```
-
-Dry-run:
-
-```bash
-scripts/runner/scale_local_runner_pool.sh \
-  --repo grace-bidos/chem-model-edit \
-  --target 4 \
-  --dry-run
-```
-
 ## 7) Fast rollback
 
 Immediate rollback:
@@ -112,3 +118,118 @@ Immediate rollback:
 Hard rollback:
 
 - remove repository access from the dedicated runner group.
+
+## 8) Local runner health check (incident triage)
+
+Use this to compare local `actions.runner.*` service state against GitHub runner status:
+
+```bash
+scripts/runner/check_local_runner_health.sh \
+  --owner grace-bidos \
+  --repo chem-model-edit \
+  --labels "self-hosted,linux,x64,chem-trusted-pr"
+```
+
+Expected result:
+
+- exit code `0`: healthy
+- non-zero: degraded (service mismatch and/or offline state)
+
+Optional strict mode:
+
+```bash
+scripts/runner/check_local_runner_health.sh \
+  --owner grace-bidos \
+  --repo chem-model-edit \
+  --strict-gh
+```
+
+## 9) One-command local base-runner recovery
+
+When jobs are queued or the local runner is stuck offline, run:
+
+```bash
+RUNNER_OWNER=grace-bidos \
+RUNNER_REPO=chem-model-edit \
+RUNNER_LABELS="self-hosted,linux,x64,chem-trusted-pr" \
+RUNNER_GROUP="Default" \
+scripts/runner/recover_base_runner.sh --runner-home /opt/actions-runner/actions-runner
+```
+
+Dry-run preview (safe):
+
+```bash
+RUNNER_OWNER=grace-bidos \
+RUNNER_REPO=chem-model-edit \
+RUNNER_LABELS="self-hosted,linux,x64,chem-trusted-pr" \
+RUNNER_GROUP="Default" \
+scripts/runner/recover_base_runner.sh \
+  --runner-home /opt/actions-runner/actions-runner \
+  --dry-run
+```
+
+Required env args are always:
+
+- `RUNNER_OWNER`
+- `RUNNER_REPO`
+- `RUNNER_LABELS`
+- `RUNNER_GROUP`
+
+## 9.1) Scale local runner pool (baseline/max/target)
+
+Use this when you want to run multiple trusted PR jobs in parallel on local self-hosted runners.
+
+Example: keep floor `1`, allow up to `4`, and scale now to `4`.
+
+```bash
+scripts/runner/scale_local_runner_pool.sh \
+  --repo grace-bidos/chem-model-edit \
+  --baseline 1 \
+  --max 4 \
+  --target 4
+```
+
+Notes:
+
+- `--target` is optional. If omitted, baseline is applied.
+- Effective target is clamped to `[baseline, max]`.
+- Runner naming remains `home-self-host`, `home-self-host-2`, ...
+
+## 9.2) Keep 4 warm slots with always-on supervisor (recommended)
+
+Use supervisor mode to avoid queue gaps between timer ticks.
+
+One-command setup:
+
+```bash
+sudo -v
+scripts/runner/setup_pool_supervisor_one_command.sh \
+  --repo grace-bidos/chem-model-edit \
+  --baseline 1 \
+  --max 4 \
+  --target 4 \
+  --interval 15
+```
+
+Dry-run:
+
+```bash
+scripts/runner/setup_pool_supervisor_one_command.sh --dry-run
+```
+
+Verify:
+
+```bash
+sudo systemctl status chem-runner-pool-supervisor.service --no-pager
+gh api repos/grace-bidos/chem-model-edit/actions/runners --jq '.runners[] | {name,status,busy}'
+```
+
+Optional: timer mode remains available as fallback, but supervisor mode should be the default for steady 4-slot operation.
+
+## 10) Emergency fallback to hosted routing
+
+If self-hosted runners are unavailable during an incident, immediately route trusted PRs back to hosted:
+
+- set repository variable `CI_SELF_HOSTED_TRUSTED_ROUTING=false`
+
+This is safe to apply before or during local runner recovery.

--- a/docs/process/self-hosted-jit-vm-operator-checklist.md
+++ b/docs/process/self-hosted-jit-vm-operator-checklist.md
@@ -76,6 +76,33 @@ After one successful dry run:
 - set `CI_SELF_HOSTED_TRUSTED_ROUTING=true`
 - open a trusted PR and verify route job selects self-hosted label target
 
+## 6.1) Scale local runner count quickly
+
+Use this helper to converge local runner instances to a target count:
+
+```bash
+scripts/runner/scale_local_runner_pool.sh \
+  --repo grace-bidos/chem-model-edit \
+  --target 2
+```
+
+Increase parallelism:
+
+```bash
+scripts/runner/scale_local_runner_pool.sh \
+  --repo grace-bidos/chem-model-edit \
+  --target 4
+```
+
+Dry-run:
+
+```bash
+scripts/runner/scale_local_runner_pool.sh \
+  --repo grace-bidos/chem-model-edit \
+  --target 4 \
+  --dry-run
+```
+
 ## 7) Fast rollback
 
 Immediate rollback:

--- a/scripts/runner/scale_local_runner_pool.sh
+++ b/scripts/runner/scale_local_runner_pool.sh
@@ -8,11 +8,18 @@ Scale local self-hosted runner pool for one repository.
 Usage:
   scripts/runner/scale_local_runner_pool.sh \
     --repo grace-bidos/chem-model-edit \
-    --target 2
+    --baseline 1 \
+    --max 4 \
+    --target 4
 
 Options:
   --repo <owner/repo>           Required.
-  --target <n>                  Required. Desired runner count (>=0).
+  --target <n>                  Optional. Desired runner count (>=0).
+                                If omitted, baseline is used.
+  --baseline <n>                Optional floor for runner count (>=0).
+                                Default: 1
+  --max <n>                     Optional upper bound for runner count (>=1).
+                                Default: 4
   --runner-user <user>          Runner OS user. Default: runner-user
   --base-dir <dir>              Runner root dir. Default: /opt/actions-runner
   --base-name <name>            Runner base name. Default: home-self-host
@@ -33,6 +40,7 @@ Notes:
   - Requires: gh, jq, sudo, systemctl
   - New runners are configured as ephemeral.
   - Script uses repository registration tokens for add/remove operations.
+  - Effective target is clamped to [baseline, max].
 EOF
 }
 
@@ -54,6 +62,16 @@ run_cmd() {
 run_sudo() {
   if [[ "$DRY_RUN" == "true" ]]; then
     echo "[dry-run] sudo $*"
+    return 0
+  fi
+  if [[ "${EUID}" -eq 0 ]]; then
+    if [[ "${1:-}" == "-u" ]]; then
+      local target_user="$2"
+      shift 2
+      runuser -u "$target_user" -- "$@"
+      return 0
+    fi
+    "$@"
     return 0
   fi
   sudo "$@"
@@ -88,10 +106,18 @@ runner_busy_in_github() {
 }
 
 registration_token() {
+  if [[ "$DRY_RUN" == "true" ]]; then
+    printf 'DRY_RUN_TOKEN\n'
+    return 0
+  fi
   gh api -X POST "repos/${REPO}/actions/runners/registration-token" --jq '.token'
 }
 
 remove_token() {
+  if [[ "$DRY_RUN" == "true" ]]; then
+    printf 'DRY_RUN_TOKEN\n'
+    return 0
+  fi
   gh api -X POST "repos/${REPO}/actions/runners/remove-token" --jq '.token'
 }
 
@@ -121,6 +147,12 @@ configure_runner() {
       local url="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${archive}"
       run_sudo -u "$RUNNER_USER" bash -lc "cd '${dir}' && curl -fsSL '${url}' -o '${archive}' && tar xzf '${archive}' && rm -f '${archive}'"
     fi
+  fi
+
+  # Clean up stale service state before reconfiguration.
+  if [[ -f "${dir}/.service" && -x "${dir}/svc.sh" ]]; then
+    run_sudo bash -lc "cd '${dir}' && ./svc.sh stop || true"
+    run_sudo bash -lc "cd '${dir}' && ./svc.sh uninstall || true"
   fi
 
   run_sudo -u "$RUNNER_USER" bash -lc "
@@ -179,6 +211,8 @@ remove_runner() {
 
 REPO=""
 TARGET=""
+BASELINE="1"
+MAX_PARALLEL="4"
 RUNNER_USER="runner-user"
 BASE_DIR="/opt/actions-runner"
 BASE_NAME="home-self-host"
@@ -192,6 +226,8 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --repo) REPO="${2:-}"; shift 2 ;;
     --target) TARGET="${2:-}"; shift 2 ;;
+    --baseline) BASELINE="${2:-}"; shift 2 ;;
+    --max) MAX_PARALLEL="${2:-}"; shift 2 ;;
     --runner-user) RUNNER_USER="${2:-}"; shift 2 ;;
     --base-dir) BASE_DIR="${2:-}"; shift 2 ;;
     --base-name) BASE_NAME="${2:-}"; shift 2 ;;
@@ -205,42 +241,81 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "$REPO" || -z "$TARGET" ]]; then
-  echo "--repo and --target are required." >&2
+if [[ -z "$REPO" ]]; then
+  echo "--repo is required." >&2
   usage
   exit 1
 fi
-if ! [[ "$TARGET" =~ ^[0-9]+$ ]]; then
-  echo "--target must be a non-negative integer." >&2
+if ! [[ "$BASELINE" =~ ^[0-9]+$ ]]; then
+  echo "--baseline must be a non-negative integer." >&2
   exit 1
+fi
+if ! [[ "$MAX_PARALLEL" =~ ^[0-9]+$ ]]; then
+  echo "--max must be a non-negative integer." >&2
+  exit 1
+fi
+if [[ "$MAX_PARALLEL" -lt 1 ]]; then
+  echo "--max must be >= 1." >&2
+  exit 1
+fi
+if [[ "$BASELINE" -gt "$MAX_PARALLEL" ]]; then
+  echo "--baseline must be <= --max." >&2
+  exit 1
+fi
+if [[ -n "$TARGET" && ! "$TARGET" =~ ^[0-9]+$ ]]; then
+  echo "--target must be a non-negative integer when provided." >&2
+  exit 1
+fi
+
+requested_target="${TARGET:-$BASELINE}"
+effective_target="$requested_target"
+if [[ "$effective_target" -lt "$BASELINE" ]]; then
+  effective_target="$BASELINE"
+fi
+if [[ "$effective_target" -gt "$MAX_PARALLEL" ]]; then
+  effective_target="$MAX_PARALLEL"
 fi
 
 require_cmd gh
 require_cmd jq
-require_cmd sudo
 require_cmd systemctl
 require_cmd rsync
 
+if [[ "${EUID}" -ne 0 ]]; then
+  require_cmd sudo
+  if [[ "$DRY_RUN" != "true" ]] && ! sudo -n true >/dev/null 2>&1; then
+    echo "sudo auth is required. Run: sudo -v" >&2
+    exit 1
+  fi
+else
+  require_cmd runuser
+fi
+
 echo "Scaling runner pool for ${REPO}"
-echo "target=${TARGET} base_name=${BASE_NAME} base_dir=${BASE_DIR}"
+echo "baseline=${BASELINE} max=${MAX_PARALLEL} requested_target=${requested_target} effective_target=${effective_target}"
+echo "base_name=${BASE_NAME} base_dir=${BASE_DIR}"
 
 # Build desired name set.
 declare -A desired=()
-for ((i=1; i<=TARGET; i++)); do
+for ((i=1; i<=effective_target; i++)); do
   n="$(runner_name_for_index "$i")"
   desired["$n"]=1
 done
 
 # Ensure desired runners exist.
-for ((i=1; i<=TARGET; i++)); do
+for ((i=1; i<=effective_target; i++)); do
   n="$(runner_name_for_index "$i")"
   d="$(runner_dir_for_name "$n")"
-  if [[ -d "$d" && -x "${d}/config.sh" ]]; then
-    echo "exists: ${n}"
+  if [[ -d "$d" && -x "${d}/config.sh" && -f "${d}/.runner" ]]; then
+    echo "exists (configured): ${n}"
     run_sudo bash -lc "cd '${d}' && ./svc.sh start || true"
     continue
   fi
-  echo "create: ${n}"
+  if [[ -d "$d" && -x "${d}/config.sh" ]]; then
+    echo "reconfigure (missing .runner): ${n}"
+  else
+    echo "create: ${n}"
+  fi
   configure_runner "$n"
 done
 

--- a/scripts/runner/scale_local_runner_pool.sh
+++ b/scripts/runner/scale_local_runner_pool.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Scale local self-hosted runner pool for one repository.
+
+Usage:
+  scripts/runner/scale_local_runner_pool.sh \
+    --repo grace-bidos/chem-model-edit \
+    --target 2
+
+Options:
+  --repo <owner/repo>           Required.
+  --target <n>                  Required. Desired runner count (>=0).
+  --runner-user <user>          Runner OS user. Default: runner-user
+  --base-dir <dir>              Runner root dir. Default: /opt/actions-runner
+  --base-name <name>            Runner base name. Default: home-self-host
+  --labels <csv>                Labels for new runners.
+                                Default: self-hosted,Linux,X64,chem-trusted-pr
+  --runner-version <ver>        Actions runner version. Default: 2.331.0
+  --seed-dir <dir>              Seed runner install to copy from.
+                                Default: /opt/actions-runner/actions-runner
+  --force-remove-busy           Allow removing busy runners when scaling down.
+  --dry-run                     Print operations only.
+  -h, --help                    Show this help.
+
+Naming:
+  index 1 => <base-name>
+  index n>=2 => <base-name>-<n>
+
+Notes:
+  - Requires: gh, jq, sudo, systemctl
+  - New runners are configured as ephemeral.
+  - Script uses repository registration tokens for add/remove operations.
+EOF
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "missing command: $1" >&2
+    exit 1
+  }
+}
+
+run_cmd() {
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "[dry-run] $*"
+    return 0
+  fi
+  "$@"
+}
+
+run_sudo() {
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "[dry-run] sudo $*"
+    return 0
+  fi
+  sudo "$@"
+}
+
+runner_name_for_index() {
+  local idx="$1"
+  if [[ "$idx" -eq 1 ]]; then
+    printf '%s\n' "$BASE_NAME"
+  else
+    printf '%s-%s\n' "$BASE_NAME" "$idx"
+  fi
+}
+
+runner_dir_for_name() {
+  local name="$1"
+  printf '%s/%s\n' "$BASE_DIR" "$name"
+}
+
+runner_exists_in_github() {
+  local name="$1"
+  gh api "repos/${REPO}/actions/runners" \
+    --jq ".runners[] | select(.name==\"${name}\") | .id" \
+    2>/dev/null | sed -n '1p'
+}
+
+runner_busy_in_github() {
+  local name="$1"
+  gh api "repos/${REPO}/actions/runners" \
+    --jq ".runners[] | select(.name==\"${name}\") | .busy" \
+    2>/dev/null | sed -n '1p'
+}
+
+registration_token() {
+  gh api -X POST "repos/${REPO}/actions/runners/registration-token" --jq '.token'
+}
+
+remove_token() {
+  gh api -X POST "repos/${REPO}/actions/runners/remove-token" --jq '.token'
+}
+
+configure_runner() {
+  local name="$1"
+  local dir
+  dir="$(runner_dir_for_name "$name")"
+  local token
+  token="$(registration_token)"
+
+  run_sudo mkdir -p "$dir"
+  run_sudo chown -R "$RUNNER_USER:$RUNNER_USER" "$dir"
+
+  if [[ ! -x "${dir}/config.sh" ]]; then
+    if [[ -d "$SEED_DIR" && -x "${SEED_DIR}/config.sh" ]]; then
+      run_sudo rsync -a --delete \
+        --exclude ".runner" \
+        --exclude ".credentials" \
+        --exclude ".credentials_rsaparams" \
+        --exclude ".service" \
+        --exclude "_diag" \
+        --exclude "_work" \
+        --exclude "*.log" \
+        "${SEED_DIR}/" "${dir}/"
+    else
+      local archive="actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+      local url="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${archive}"
+      run_sudo -u "$RUNNER_USER" bash -lc "cd '${dir}' && curl -fsSL '${url}' -o '${archive}' && tar xzf '${archive}' && rm -f '${archive}'"
+    fi
+  fi
+
+  run_sudo -u "$RUNNER_USER" bash -lc "
+    set -euo pipefail
+    cd '${dir}'
+    ./config.sh \
+      --url 'https://github.com/${REPO}' \
+      --token '${token}' \
+      --name '${name}' \
+      --labels '${LABELS}' \
+      --work '_work' \
+      --ephemeral \
+      --unattended \
+      --replace
+  "
+
+  run_sudo bash -lc "cd '${dir}' && ./svc.sh install '${RUNNER_USER}'"
+  run_sudo bash -lc "cd '${dir}' && ./svc.sh start"
+}
+
+remove_runner() {
+  local name="$1"
+  local dir
+  dir="$(runner_dir_for_name "$name")"
+
+  local busy
+  busy="$(runner_busy_in_github "$name" || true)"
+  if [[ "$busy" == "true" && "$FORCE_REMOVE_BUSY" != "true" ]]; then
+    echo "skip removing busy runner: ${name}" >&2
+    return 0
+  fi
+
+  if [[ -d "$dir" && -x "${dir}/svc.sh" ]]; then
+    run_sudo bash -lc "cd '${dir}' && ./svc.sh stop || true"
+    run_sudo bash -lc "cd '${dir}' && ./svc.sh uninstall || true"
+  fi
+
+  if [[ -d "$dir" && -x "${dir}/config.sh" ]]; then
+    local token
+    token="$(remove_token)"
+    run_sudo -u "$RUNNER_USER" bash -lc "
+      set -euo pipefail
+      cd '${dir}'
+      ./config.sh remove --token '${token}' || true
+    "
+  fi
+
+  local rid
+  rid="$(runner_exists_in_github "$name" || true)"
+  if [[ -n "$rid" ]]; then
+    run_cmd gh api -X DELETE "repos/${REPO}/actions/runners/${rid}"
+  fi
+
+  run_sudo rm -rf "$dir"
+}
+
+REPO=""
+TARGET=""
+RUNNER_USER="runner-user"
+BASE_DIR="/opt/actions-runner"
+BASE_NAME="home-self-host"
+LABELS="self-hosted,Linux,X64,chem-trusted-pr"
+RUNNER_VERSION="2.331.0"
+SEED_DIR="/opt/actions-runner/actions-runner"
+FORCE_REMOVE_BUSY="false"
+DRY_RUN="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO="${2:-}"; shift 2 ;;
+    --target) TARGET="${2:-}"; shift 2 ;;
+    --runner-user) RUNNER_USER="${2:-}"; shift 2 ;;
+    --base-dir) BASE_DIR="${2:-}"; shift 2 ;;
+    --base-name) BASE_NAME="${2:-}"; shift 2 ;;
+    --labels) LABELS="${2:-}"; shift 2 ;;
+    --runner-version) RUNNER_VERSION="${2:-}"; shift 2 ;;
+    --seed-dir) SEED_DIR="${2:-}"; shift 2 ;;
+    --force-remove-busy) FORCE_REMOVE_BUSY="true"; shift 1 ;;
+    --dry-run) DRY_RUN="true"; shift 1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [[ -z "$REPO" || -z "$TARGET" ]]; then
+  echo "--repo and --target are required." >&2
+  usage
+  exit 1
+fi
+if ! [[ "$TARGET" =~ ^[0-9]+$ ]]; then
+  echo "--target must be a non-negative integer." >&2
+  exit 1
+fi
+
+require_cmd gh
+require_cmd jq
+require_cmd sudo
+require_cmd systemctl
+require_cmd rsync
+
+echo "Scaling runner pool for ${REPO}"
+echo "target=${TARGET} base_name=${BASE_NAME} base_dir=${BASE_DIR}"
+
+# Build desired name set.
+declare -A desired=()
+for ((i=1; i<=TARGET; i++)); do
+  n="$(runner_name_for_index "$i")"
+  desired["$n"]=1
+done
+
+# Ensure desired runners exist.
+for ((i=1; i<=TARGET; i++)); do
+  n="$(runner_name_for_index "$i")"
+  d="$(runner_dir_for_name "$n")"
+  if [[ -d "$d" && -x "${d}/config.sh" ]]; then
+    echo "exists: ${n}"
+    run_sudo bash -lc "cd '${d}' && ./svc.sh start || true"
+    continue
+  fi
+  echo "create: ${n}"
+  configure_runner "$n"
+done
+
+# Scale down extra managed runners matching base pattern.
+mapfile -t all_names < <(gh api "repos/${REPO}/actions/runners" --jq '.runners[].name' 2>/dev/null || true)
+for n in "${all_names[@]}"; do
+  if [[ "$n" == "$BASE_NAME" || "$n" =~ ^${BASE_NAME}-[0-9]+$ ]]; then
+    if [[ -z "${desired[$n]+x}" ]]; then
+      echo "remove: ${n}"
+      remove_runner "$n"
+    fi
+  fi
+done
+
+echo "Done."


### PR DESCRIPTION
## Summary
- add `scripts/runner/scale_local_runner_pool.sh` to scale local self-hosted runner instances with sudo-safe operations
- support target-based converge (`--target N`) with create/start/remove behavior
- reuse seed runner install for faster bootstrap and keep runners ephemeral
- document copy-paste usage in operator checklist

## Testing
- bash -n scripts/runner/scale_local_runner_pool.sh
- git diff --check

Linear Issue: GRA-99
Type: Show
Size: S
Queue Policy: Required
Stack: Standalone

## CodeRabbit Policy
- [x] Required (product/API/auth/worker behavior changed)
- [ ] Optional (process/docs/template/script-only change)

Refs GRA-99


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to scale local self-hosted runner instances to a target count with dry-run support for safer deployments.

* **Documentation**
  * Added scaling workflow instructions with usage examples to the self-hosted runner operator checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->