### PR TITLE
GRA-111: Add optional CI smoke check for submit-event-projection harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       web: ${{ steps.filter.outputs.web == 'true' || steps.filter.outputs.ci == 'true' }}
       api: ${{ steps.filter.outputs.api == 'true' || steps.filter.outputs.ci == 'true' }}
       contract: ${{ steps.filter.outputs.contract == 'true' || steps.filter.outputs.ci == 'true' }}
+      # Intentionally independent from `ci` global toggle: keep this lane opt-in and scoped.
       projection_smoke: ${{ steps.filter.outputs.projection_smoke == 'true' }}
     steps:
       - name: Checkout
@@ -57,11 +58,8 @@ jobs:
             projection_smoke:
               - 'apps/api/**'
               - 'packages/api-client/**'
-              - 'packages/shared/**'
               - 'pyproject.toml'
               - 'uv.lock'
-              - 'pnpm-lock.yaml'
-              - 'pnpm-workspace.yaml'
               - 'scripts/submit-event-projection-smoke.sh'
 
   route:


### PR DESCRIPTION
Linear Issue: GRA-111
Type: Ship
Size: XS
Queue Policy: Optional
Stack: Standalone

## Summary
- add optional `projection-smoke` CI job to run submit->event->projection smoke harness on API/contract changes
- keep existing required CI gates unchanged (`continue-on-error: true`)
- tighten smoke script for CI determinism (`uv sync --frozen` + `uv run --no-sync`)

## Validation
- `bash -n scripts/submit-event-projection-smoke.sh`
- `bash scripts/submit-event-projection-smoke.sh`

## CodeRabbit Policy
- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added automated smoke tests to the continuous integration pipeline to improve quality assurance and system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->