### PR TITLE
fix: Ubuntu 24.04 compatibility for slurm vm validator

### DIFF
--- a/docs/process/slurm-vm-control-plane-runbook.md
+++ b/docs/process/slurm-vm-control-plane-runbook.md
@@ -70,7 +70,7 @@ What this verifies:
 What this intentionally skips:
 
 - Service state checks
-- Runtime checks (`munge -n | unmunge`, `slurmctld -t`, `slurmd -t`, `scontrol ping`)
+- Runtime checks (`munge -n | unmunge`, `SLURM_CONF=<path> slurmctld -V`, `SLURM_CONF=<path> slurmd -C`, `SLURM_CONF=<path> scontrol ping`)
 
 ## Exit Codes
 

--- a/scripts/validate-slurm-vm-control-plane.sh
+++ b/scripts/validate-slurm-vm-control-plane.sh
@@ -310,9 +310,9 @@ validate_runtime() {
   fi
 
   run_runtime_check "munge encode/decode" bash -lc "munge -n | unmunge >/dev/null"
-  run_runtime_check "slurmctld version probe" slurmctld -V
-  run_runtime_check "slurmd capability probe" slurmd -C
-  run_runtime_check "scontrol ping" scontrol ping
+  run_runtime_check "slurmctld version probe (selected slurm.conf)" env "SLURM_CONF=$SLURM_CONF" slurmctld -V
+  run_runtime_check "slurmd capability probe (selected slurm.conf)" env "SLURM_CONF=$SLURM_CONF" slurmd -C
+  run_runtime_check "scontrol ping (selected slurm.conf)" env "SLURM_CONF=$SLURM_CONF" scontrol ping
 
   if have_command systemctl; then
     local service


### PR DESCRIPTION
## Summary
- improve Ubuntu 24.04 compatibility in `scripts/validate-slurm-vm-control-plane.sh`
- avoid false blockers for munge key metadata checks when running as non-root
- replace non-portable Slurm daemon probes with portable runtime probes

Linear Issue: GRA-89
Type: Ship
Size: S
Queue Policy: Optional
Stack: Standalone

## Validation
- `bash -n scripts/validate-slurm-vm-control-plane.sh`
- `scripts/validate-slurm-vm-control-plane.sh --mode offline`

## CodeRabbit Policy
- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)
