### PR TITLE
Add VM secret rotation playbook for validation lanes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,11 @@ pnpm-debug.log*
 .xdg-runtime
 .just-runtime
 
+# Local-only VM credential artifacts
+.tmp/vm-validation-secrets/
+.tmp/vm-jit-config/
+.secrets/vm-validation/
+
 # User uploads (temporary)
 /uploads
 

--- a/docs/process/vm-validation-secret-rotation-playbook.md
+++ b/docs/process/vm-validation-secret-rotation-playbook.md
@@ -1,0 +1,77 @@
+# VM Validation Lane Secret Rotation Playbook (GRA-123)
+
+This playbook defines what to do when VM validation lane credentials are exposed, suspected exposed, or intentionally rotated.
+
+## Scope
+
+- VM validation lanes and helper scripts used by lane owners.
+- Local temporary artifacts for JIT config and VM credentials.
+- Process-only guidance; do not store real secrets in the repository.
+
+## Trigger Conditions
+
+Run this playbook when any of the following occurs:
+
+- secret material appears in terminal history, logs, screenshots, or PR comments
+- temporary credential files were created in the repository by mistake
+- a key/token age policy requires scheduled rotation
+- credentials are shared across operators and ownership changes
+
+## Immediate Response (First 15 Minutes)
+
+1. Stop active automation that may still consume leaked credentials.
+2. Revoke or rotate exposed credentials in the source system first.
+3. Invalidate all local temporary files and shell variables.
+4. Replace local files with newly issued credentials only in local ignored paths.
+5. Record the incident in the linked Linear child issue and describe blast radius.
+
+## Safe Local Handling Rules
+
+- Store temporary VM/JIT credentials only under:
+  - `.tmp/vm-validation-secrets/`
+  - `.tmp/vm-jit-config/`
+  - `.secrets/vm-validation/`
+- Never commit temporary credentials, even if encrypted.
+- Do not paste raw secret values into PR descriptions, issue comments, or CI logs.
+- Prefer short-lived credentials and one-time artifacts.
+- Remove credentials after each validation run.
+
+## Rotation Checklist
+
+Use this checklist for every rotation event:
+
+- [ ] Old credential revoked/disabled in provider control plane.
+- [ ] New credential created with least privilege.
+- [ ] Runtime consumer updated (VM, runner, or operator environment).
+- [ ] Validation lane rerun confirms healthy authentication.
+- [ ] Local temporary files cleaned with `scripts/runner/cleanup_vm_temp_credentials.sh`.
+- [ ] Incident notes added to the related Linear issue (no raw secret values).
+
+## Verification Commands
+
+Basic local verification before/after rotation:
+
+```bash
+# Dry-run cleanup visibility
+scripts/runner/cleanup_vm_temp_credentials.sh --dry-run
+
+# Perform cleanup without prompt (CI-safe/local automation)
+scripts/runner/cleanup_vm_temp_credentials.sh --force
+```
+
+## Local Artifact Cleanup Policy
+
+- Use the cleanup script after each VM lane run and after any failed attempt.
+- If manual cleanup is required, delete only files under ignored local paths.
+- If an artifact location is outside allowed local paths, stop and handle manually.
+
+## Reporting Requirements
+
+When rotation happens, include in the lane handoff:
+
+- what was rotated (token/key category only)
+- when it was rotated (UTC timestamp)
+- what systems were updated
+- confirmation that local temporary artifacts were removed
+
+Do not include secret values, partial values, or screenshots containing credentials.

--- a/scripts/runner/cleanup_vm_temp_credentials.sh
+++ b/scripts/runner/cleanup_vm_temp_credentials.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/runner/cleanup_vm_temp_credentials.sh [options]
+
+Safely remove local temporary VM credential artifacts from ignored paths.
+
+Options:
+  --path <path>   Add an extra target path (repeatable).
+  --dry-run       Show what would be removed without deleting.
+  --force         Delete without confirmation prompt.
+  -h, --help      Show help.
+
+Default target paths:
+  .tmp/vm-validation-secrets
+  .tmp/vm-jit-config
+  .secrets/vm-validation
+
+Safety guard:
+  Only paths under .tmp/ or .secrets/ in this repository are allowed.
+USAGE
+}
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DRY_RUN=0
+FORCE=0
+
+declare -a TARGETS=(
+  ".tmp/vm-validation-secrets"
+  ".tmp/vm-jit-config"
+  ".secrets/vm-validation"
+)
+
+declare -a NORMALIZED_TARGETS=()
+declare -a REMOVABLE_PATHS=()
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+normalize_path() {
+  local raw="$1"
+  local abs
+
+  if [[ "$raw" = /* ]]; then
+    abs="$raw"
+  else
+    abs="$ROOT_DIR/$raw"
+  fi
+
+  if command -v realpath >/dev/null 2>&1; then
+    realpath -m "$abs"
+    return
+  fi
+
+  if command -v readlink >/dev/null 2>&1; then
+    readlink -m "$abs"
+    return
+  fi
+
+  die "realpath or readlink is required for safe path normalization"
+}
+
+is_allowed_path() {
+  local path="$1"
+  case "$path" in
+    "$ROOT_DIR"/.tmp/*|"$ROOT_DIR"/.secrets/*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --path)
+      [[ $# -gt 1 ]] || die "--path requires a value"
+      TARGETS+=("$2")
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --force)
+      FORCE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+for target in "${TARGETS[@]}"; do
+  normalized="$(normalize_path "$target")"
+  NORMALIZED_TARGETS+=("$normalized")
+  if ! is_allowed_path "$normalized"; then
+    die "refusing to touch path outside .tmp/ or .secrets/: $target -> $normalized"
+  fi
+
+done
+
+for path in "${NORMALIZED_TARGETS[@]}"; do
+  if [[ -e "$path" ]]; then
+    REMOVABLE_PATHS+=("$path")
+  fi
+done
+
+if [[ ${#REMOVABLE_PATHS[@]} -eq 0 ]]; then
+  echo "No local VM credential artifacts found."
+  exit 0
+fi
+
+echo "Cleanup targets:"
+for path in "${REMOVABLE_PATHS[@]}"; do
+  echo "- $path"
+done
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "Dry-run enabled. No files were removed."
+  exit 0
+fi
+
+if [[ "$FORCE" -ne 1 ]]; then
+  read -r -p "Proceed with deletion? [y/N] " response
+  if [[ ! "$response" =~ ^[Yy]$ ]]; then
+    echo "Aborted."
+    exit 1
+  fi
+fi
+
+for path in "${REMOVABLE_PATHS[@]}"; do
+  rm -rf -- "$path"
+done
+
+echo "Cleanup complete."


### PR DESCRIPTION
# Summary

- Add a VM validation lane secret rotation playbook and a safe local cleanup helper for temporary credential artifacts.

## Work Item Metadata

- Linear Issue: GRA-123
- Type: Ship
- Size: S
- Queue Policy: Optional
- Stack: Standalone

## Linked Issues

- None

## Changes

- Added `docs/process/vm-validation-secret-rotation-playbook.md` with exposure triggers, immediate response steps, rotation checklist, and reporting requirements.
- Added `scripts/runner/cleanup_vm_temp_credentials.sh` to remove temporary VM/JIT credential artifacts with path safety guards and dry-run/force modes.
- Updated `.gitignore` with local-only VM credential artifact paths used by the cleanup playbook and helper script.

## Validation

- [x] Local checks passed
- [ ] Added/updated tests where needed

## Temporary Behavior

- [x] None
- [ ] Present (describe clearly below)
- Description:

## Final Behavior

- Lane owners have a documented secret rotation response for VM validation lanes.
- Temporary local credential artifacts are cleaned up via an explicit safe helper command.
- Repository ignore rules prevent accidental tracking of local VM credential files.

## Follow-up Issue/PR (if any)

- [x] None
- [ ] Required (link issue/PR)
- Link:

## CodeRabbit Policy

- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)
