### PR TITLE
Define Slurm verification boundary tiers (GRA-66)

### DIFF
--- a/docs/process/slurm-verification-boundary.md
+++ b/docs/process/slurm-verification-boundary.md
@@ -1,0 +1,35 @@
+# Slurm Verification Boundary (GRA-66)
+
+This note defines what we should verify without a real Slurm cluster vs what must run against real Slurm.
+
+## Tier Definitions
+
+- Tier-1 (contract/mocks): deterministic checks runnable on developer machines/CI without `slurmctld`.
+- Tier-2 (local VM real Slurm smoke): minimal real-runtime checks on a VM where Slurm + AiiDA are installed.
+- Tier-3 (optional shared cluster): non-blocking confidence checks on a shared/remote cluster environment.
+
+## Boundary Map
+
+| Check area | Tier | Why this tier | Concrete repo command examples |
+| --- | --- | --- | --- |
+| Slurm queue policy contract and fallback semantics (`route-default` / `deny`) | Tier-1 | Pure Python/JSON validation; no scheduler RPC | `uv run pytest apps/api/tests/test_zpe_slurm_policy.py` |
+| BYO onboarding schema and queue-resolution CLI contract | Tier-1 | Script + fixtures only; no real `sinfo`/`sbatch` invocation | `uv run pytest apps/api/tests/test_validate_slurm_onboarding.py`<br>`python3 scripts/validate-slurm-onboarding.py --policy apps/api/config/slurm/onboarding.policy.example.json --registration apps/api/config/slurm/node-registration.example.json --requested-queue standard` |
+| HTTP worker payload compatibility carrying Slurm metadata fields (`slurm_job_id`, partition, qos) | Tier-1 | Local HTTP server + mock worker mode; validates API contract, not scheduler behavior | `uv run pytest apps/api/tests/test_zpe_http_worker_integration.py` |
+| Queue/target and enqueue path behavior (`fakeredis`) | Tier-1 | Redis mocked; no Slurm runtime dependency | `uv run pytest apps/api/tests/test_zpe_http_queue.py apps/api/tests/test_zpe_queue_targets.py` |
+| Slurm VM control-plane config static validation | Tier-1 | Offline fixture-based deterministic checks | `scripts/validate-slurm-vm-offline.sh` |
+| VM control-plane runtime health (`munge`, `slurmctld`, `slurmd`, `scontrol ping`, `sinfo`) | Tier-2 | Requires running Slurm services and host-level runtime state | `scripts/validate-slurm-vm-control-plane.sh --mode vm` |
+| AiiDA -> Slurm minimal smoke (`verdi computer test core.slurm`) on VM | Tier-2 | Requires reachable Slurm controller and AiiDA scheduler integration | `scripts/aiida-slurm-smoke-vm.sh --artifact-dir investigations/artifacts/gra-89/manual` |
+| Remote rerun of VM smoke from lane machine | Tier-2 | Still real Slurm, but execution is remote via SSH | `scripts/aiida-slurm-smoke-vm-remote.sh --host <vm-host> --user <vm-user>` |
+| Full promotion-gate style remote VM flow (bootstrap + Slurm smoke) | Tier-3 | Broader operational confidence check; useful before cutover, not required per commit | `scripts/aiida-promotion-gate-vm-remote.sh --host <vm-host> --user <vm-user>` |
+| Shared cluster validation of queue/account/qos policy in real environment | Tier-3 | Depends on external tenancy/policy and cluster availability; should be scheduled, not blocking | `scripts/aiida-slurm-smoke-vm.sh --profile <profile> --computer-label <shared-cluster-label>` |
+
+## Practical Gate Recommendation
+
+- PR gate default: Tier-1 only.
+- Release/cutover gate: Tier-1 + Tier-2.
+- Tier-3: run on demand (pre-cutover, incident repro, or policy drift checks).
+
+## Notes on Existing E2E Tests
+
+- `apps/api/tests/test_zpe_e2e_h2.py` and `apps/api/tests/test_zpe_e2e_molecules.py` require Quantum ESPRESSO binaries/pseudos, but they do not require Slurm.
+- Keep them outside mandatory Slurm boundary checks unless intentionally executed on a Slurm-backed host for additional confidence.


### PR DESCRIPTION
# Summary

- Define a verification boundary for Slurm-related backend checks so day-to-day PR validation can stay deterministic while preserving real-runtime confidence paths.

## Work Item Metadata

- Linear Issue: GRA-66
- Type: Ask
- Size: S
- Queue Policy: Optional
- Stack: Standalone

## Linked Issues

- None

## Changes

- Added `docs/process/slurm-verification-boundary.md`.
- Classified current repo checks into three tiers:
  - Tier-1 contract/mocks (CI-friendly, no real Slurm required)
  - Tier-2 local VM real Slurm smoke
  - Tier-3 optional shared-cluster confidence checks
- Mapped concrete test/script entry points to each tier with executable command examples from the repository.
- Added gate recommendations (PR default vs release/cutover).

## Validation

- [ ] Local checks passed
- [ ] Added/updated tests where needed
- Validation notes: docs-only change; no automated checks executed for this PR.

## Temporary Behavior

- [x] None
- [ ] Present (describe clearly below)
- Description:

## Final Behavior

- Team has an explicit, repo-grounded boundary for what must run with real Slurm vs what should remain in deterministic contract/mocked validation.

## Follow-up Issue/PR (if any)

- [x] None
- [ ] Required (link issue/PR)
- Link:

## CodeRabbit Policy

- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation detailing Slurm verification boundaries, tier definitions, verification checks with example commands, and gate recommendations for release criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->