### PR TITLE
CI: harden self-hosted lane security and cache reuse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary
- add top-level least-privilege `permissions` for CI
- add workflow `concurrency` to cancel stale in-flight runs per PR/ref
- disable checkout credential persistence in all CI jobs
- improve pnpm cache reuse and reuse-safe install behavior
- enable uv cache reuse keyed by lock/pyproject in API and contract jobs
- switch CI Python runtime for `api` and `contract` jobs to 3.12 for faster wheel availability

## Why
- reduce queue pressure and stale-run contention on self-hosted runners
- reduce token exposure surface in job workspaces
- speed up repeated installs and improve CI throughput

## Metadata
Linear Issue: GRA-118
Type: Ship
Size: S
Queue Policy: Optional
Stack: Standalone

## CodeRabbit Policy
- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)

## Notes
- no runtime feature behavior change; this PR only hardens CI execution and cache strategy
