### PR TITLE
GRA-79: one-command management-node enrollment installer UX

### DIFF
--- a/docs/process/management-node-user-enrollment-bootstrap.md
+++ b/docs/process/management-node-user-enrollment-bootstrap.md
@@ -1,0 +1,71 @@
+# Management Node User Enrollment Bootstrap
+
+This runbook provides a one-command setup flow for management-node user enrollment.
+
+## Purpose
+
+- Install the latest (or pinned) `bootstrap-management-node.sh` helper.
+- Verify script integrity with SHA-256 checksum by default.
+- Run enrollment in safe mode by default (dry-run unless `--apply` is passed).
+
+## One-Command Quick Start
+
+Run from any machine with `bash` and `curl`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/grace-bidos/chem-model-edit/main/scripts/install-management-node.sh \
+  | bash -s -- --management-host localhost --user chemops
+```
+
+The command above executes only a dry-run plan. No remote changes are applied unless you add `--apply`.
+
+## Version Pinning
+
+Pin to a specific branch, tag, or commit by setting `MANAGEMENT_NODE_VERSION`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/grace-bidos/chem-model-edit/main/scripts/install-management-node.sh \
+  | MANAGEMENT_NODE_VERSION=v0.1.0 bash -s -- --management-host localhost --user chemops
+```
+
+You can also set a commit SHA:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/grace-bidos/chem-model-edit/main/scripts/install-management-node.sh \
+  | MANAGEMENT_NODE_VERSION=<commit-sha> bash -s -- --management-host localhost --user chemops
+```
+
+## Checksum Verification Policy
+
+- Default: checksum verification is enabled.
+- Source checksum file: `scripts/bootstrap-management-node.sh.sha256`.
+- Disable only for emergency debugging:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/grace-bidos/chem-model-edit/main/scripts/install-management-node.sh \
+  | bash -s -- --no-verify-checksum --management-host localhost --user chemops
+```
+
+## Apply Mode
+
+Dry-run is default. To apply changes, pass `--apply` through to bootstrap:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/grace-bidos/chem-model-edit/main/scripts/install-management-node.sh \
+  | bash -s -- --management-host localhost --user chemops --apply
+```
+
+## Local Repository Usage
+
+When working from a checked-out repository:
+
+```bash
+scripts/install-management-node.sh --management-host localhost --user chemops
+```
+
+## Installer Environment Variables
+
+- `MANAGEMENT_NODE_VERSION` (default: `main`)
+- `MANAGEMENT_NODE_REPOSITORY` (default: `grace-bidos/chem-model-edit`)
+- `MANAGEMENT_NODE_INSTALL_DIR` (default: `/tmp/management-node-enrollment`)
+- `MANAGEMENT_NODE_VERIFY_CHECKSUM` (default: `true`)

--- a/docs/process/slurm-byo-onboarding.md
+++ b/docs/process/slurm-byo-onboarding.md
@@ -12,6 +12,7 @@ Scope of this slice (`GRA-15`):
 Related baseline:
 
 - `docs/process/aiida-runtime-bootstrap.md` (AiiDA runtime bootstrap safety model)
+- `docs/process/management-node-user-enrollment-bootstrap.md` (one-command management-node enrollment setup)
 
 ## Onboarding Requirements
 

--- a/investigations/gra-79-one-command-management-node-enrollment.md
+++ b/investigations/gra-79-one-command-management-node-enrollment.md
@@ -1,0 +1,52 @@
+# GRA-79 - One-command management-node enrollment setup
+
+## Goal
+
+Provide an operator-friendly one-command UX to run management-node user enrollment with safe defaults and checksum protection.
+
+## Scope
+
+- Add installer script: `scripts/install-management-node.sh`.
+- Add checksum artifact: `scripts/bootstrap-management-node.sh.sha256`.
+- Keep `scripts/bootstrap-management-node.sh` behavior unchanged and safe by default.
+- Document usage and guardrails.
+
+## Decisions
+
+### 1) Keep bootstrap as execution source of truth
+
+The installer only downloads, verifies, and executes `bootstrap-management-node.sh`. All enrollment logic remains in bootstrap.
+
+### 2) Checksum verification default ON
+
+Installer downloads both files:
+
+- `bootstrap-management-node.sh`
+- `bootstrap-management-node.sh.sha256`
+
+Then it runs `sha256sum -c` unless explicitly disabled with `--no-verify-checksum` or `MANAGEMENT_NODE_VERIFY_CHECKSUM=false`.
+
+### 3) Version pin support
+
+Installer supports pinning via `MANAGEMENT_NODE_VERSION` and resolves files from:
+
+`https://raw.githubusercontent.com/<repo>/<version>/scripts/...`
+
+This works for branch, tag, or commit SHA pins.
+
+### 4) Safe execution preserved
+
+Installer forwards unknown arguments directly to bootstrap. Since bootstrap defaults to dry-run, the one-command flow is safe by default and requires explicit `--apply` to mutate systems.
+
+## Verification Plan
+
+- Syntax validation:
+  - `bash -n scripts/install-management-node.sh scripts/bootstrap-management-node.sh`
+- Enrollment harness (if feasible):
+  - `scripts/verify-management-node-enrollment-docker.sh`
+
+## Risks and Notes
+
+- The installer assumes `curl` or `wget` is available.
+- Checksum verification requires `sha256sum`.
+- Network access is required for raw GitHub downloads when not running from local repo paths.

--- a/scripts/bootstrap-management-node.sh.sha256
+++ b/scripts/bootstrap-management-node.sh.sha256
@@ -1,0 +1,1 @@
+268c9defbc8f371f9db84c8f85912efa64fb3b3cde379ff47c7e81b84eaa712a  bootstrap-management-node.sh

--- a/scripts/install-management-node.sh
+++ b/scripts/install-management-node.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MANAGEMENT_NODE_VERSION="${MANAGEMENT_NODE_VERSION:-main}"
+MANAGEMENT_NODE_REPOSITORY="${MANAGEMENT_NODE_REPOSITORY:-grace-bidos/chem-model-edit}"
+MANAGEMENT_NODE_INSTALL_DIR="${MANAGEMENT_NODE_INSTALL_DIR:-${TMPDIR:-/tmp}/management-node-enrollment}"
+MANAGEMENT_NODE_VERIFY_CHECKSUM="${MANAGEMENT_NODE_VERIFY_CHECKSUM:-true}"
+DOWNLOAD_ONLY=0
+BOOTSTRAP_ARGS=()
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [installer-options] [-- bootstrap-options]
+
+Download and run management-node enrollment bootstrap script.
+Checksum verification is enabled by default.
+
+Installer options:
+  --version <value>          Set MANAGEMENT_NODE_VERSION (default: main)
+  --install-dir <path>       Download directory (default: /tmp/management-node-enrollment)
+  --verify-checksum          Enable checksum verification (default)
+  --no-verify-checksum       Disable checksum verification
+  --download-only            Download files without running bootstrap script
+  -h, --help                 Show this help
+
+Environment overrides:
+  MANAGEMENT_NODE_VERSION
+  MANAGEMENT_NODE_REPOSITORY
+  MANAGEMENT_NODE_INSTALL_DIR
+  MANAGEMENT_NODE_VERIFY_CHECKSUM
+
+Notes:
+  - Bootstrap script remains safe by default and requires --apply for changes.
+  - Unknown flags are forwarded to bootstrap-management-node.sh.
+USAGE
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+parse_bool() {
+  case "$1" in
+    true|false) printf '%s\n' "$1" ;;
+    *) die "invalid boolean value: $1 (expected true or false)" ;;
+  esac
+}
+
+have_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+download_file() {
+  local url="$1"
+  local output="$2"
+
+  if have_cmd curl; then
+    curl -fsSL "$url" -o "$output"
+    return 0
+  fi
+
+  if have_cmd wget; then
+    wget -qO "$output" "$url"
+    return 0
+  fi
+
+  die "missing downloader: install curl or wget"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      shift
+      [[ $# -gt 0 ]] || die "--version requires a value"
+      MANAGEMENT_NODE_VERSION="$1"
+      ;;
+    --install-dir)
+      shift
+      [[ $# -gt 0 ]] || die "--install-dir requires a value"
+      MANAGEMENT_NODE_INSTALL_DIR="$1"
+      ;;
+    --verify-checksum)
+      MANAGEMENT_NODE_VERIFY_CHECKSUM="true"
+      ;;
+    --no-verify-checksum)
+      MANAGEMENT_NODE_VERIFY_CHECKSUM="false"
+      ;;
+    --download-only)
+      DOWNLOAD_ONLY=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      while [[ $# -gt 0 ]]; do
+        BOOTSTRAP_ARGS+=("$1")
+        shift
+      done
+      break
+      ;;
+    *)
+      BOOTSTRAP_ARGS+=("$1")
+      ;;
+  esac
+  shift
+done
+
+MANAGEMENT_NODE_VERIFY_CHECKSUM="$(parse_bool "$MANAGEMENT_NODE_VERIFY_CHECKSUM")"
+BASE_URL="https://raw.githubusercontent.com/${MANAGEMENT_NODE_REPOSITORY}/${MANAGEMENT_NODE_VERSION}/scripts"
+
+mkdir -p "$MANAGEMENT_NODE_INSTALL_DIR"
+BOOTSTRAP_PATH="$MANAGEMENT_NODE_INSTALL_DIR/bootstrap-management-node.sh"
+CHECKSUM_PATH="$MANAGEMENT_NODE_INSTALL_DIR/bootstrap-management-node.sh.sha256"
+
+printf 'Downloading bootstrap script from %s\n' "$BASE_URL"
+download_file "$BASE_URL/bootstrap-management-node.sh" "$BOOTSTRAP_PATH"
+download_file "$BASE_URL/bootstrap-management-node.sh.sha256" "$CHECKSUM_PATH"
+
+if [[ "$MANAGEMENT_NODE_VERIFY_CHECKSUM" == "true" ]]; then
+  have_cmd sha256sum || die "sha256sum is required for checksum verification"
+  (
+    cd "$MANAGEMENT_NODE_INSTALL_DIR"
+    sha256sum -c "$(basename "$CHECKSUM_PATH")" --status
+  ) || die "checksum verification failed"
+  printf 'Checksum verification: passed\n'
+else
+  printf 'Checksum verification: skipped\n'
+fi
+
+chmod +x "$BOOTSTRAP_PATH"
+
+if [[ "$DOWNLOAD_ONLY" -eq 1 ]]; then
+  printf 'Downloaded files:\n'
+  printf '  %s\n' "$BOOTSTRAP_PATH"
+  printf '  %s\n' "$CHECKSUM_PATH"
+  exit 0
+fi
+
+printf 'Running bootstrap script (safe default is dry-run unless --apply is passed).\n'
+exec "$BOOTSTRAP_PATH" "${BOOTSTRAP_ARGS[@]}"


### PR DESCRIPTION
# Summary

- Implement one-command management-node user-enrollment setup UX with checksum-verified installer and runbook docs.

## Work Item Metadata

- Linear Issue: GRA-79
- Type: Show
- Size: S
- Queue Policy: Optional
- Stack: Standalone

## Linked Issues

- GRA-79

## Changes

- Added `scripts/install-management-node.sh` to download bootstrap artifacts and run enrollment.
- Added default-on checksum enforcement via `scripts/bootstrap-management-node.sh.sha256`.
- Added one-command operator runbook in `docs/process/management-node-user-enrollment-bootstrap.md`.
- Added implementation notes in `investigations/gra-79-one-command-management-node-enrollment.md`.
- Added a minimal cross-reference link in `docs/process/slurm-byo-onboarding.md`.

## Validation

- [x] Local checks passed
- [ ] Added/updated tests where needed

## Temporary Behavior

- [x] None
- [ ] Present (describe clearly below)
- Description:

## Final Behavior

- Operators can run one command to fetch and execute management-node enrollment bootstrap with checksum verification enabled by default and explicit `--apply` required for changes.

## Follow-up Issue/PR (if any)

- [x] None
- [ ] Required (link issue/PR)
- Link:

## CodeRabbit Policy

- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)
