### PR TITLE
GRA-127: Guard CI against duplicate warm-caches definitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,8 @@ jobs:
           fi
           echo "trusted=${trusted}" >> "${GITHUB_OUTPUT}"
 
+  # Cache topology is intentionally per lane. Keep cache restore/save close to each
+  # consumer job and do not reintroduce a shared `warm-caches` pre-job.
   web:
     needs:
       - changes


### PR DESCRIPTION
## Summary
- used the dirty backup file `/tmp/chem-model-edit-dirty-backup/ci.yml.dirty` as reference to confirm the duplicate `warm-caches` pattern
- kept the current intentional per-lane cache topology in `.github/workflows/ci.yml`
- added an explicit guardrail comment so duplicate shared `warm-caches` jobs are not reintroduced

## Validation
- `python3` YAML parse check for `.github/workflows/ci.yml`
- `actionlint` is not available locally in this environment
- `pnpm exec prettier -c .github/workflows/ci.yml` could not run locally because `prettier` is not installed in this environment

## Metadata
Linear Issue: GRA-127
Type: Ship
Size: S
Queue Policy: Optional
Stack: Standalone

## CodeRabbit Policy
- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)
