### PR TITLE
GRA-128: Evaluate uv.lock dirty delta and document discard decision

### DIFF
--- a/investigations/gra-128-uvlock-delta-decision-2026-02-17.md
+++ b/investigations/gra-128-uvlock-delta-decision-2026-02-17.md
@@ -1,0 +1,30 @@
+# GRA-128: uv.lock dirty delta evaluation (2026-02-17)
+
+## Scope
+Compared:
+- `/tmp/chem-model-edit-dirty-backup/uv.lock.dirty`
+- `apps/api/uv.lock` (current `main`)
+- `apps/api/pyproject.toml` (current `main`)
+
+## Findings
+- Lockfile drift is very large: `1071 insertions`, `52 deletions`.
+- Dirty lock introduces a full `aiida-core` transitive tree (e.g. `aiida-core`, `aio-pika`, `plumpy`, `sqlalchemy`, `psycopg`, etc.).
+- Dirty lock also changes versions of already shared packages, including downgrades:
+  - `click 8.3.1 -> 8.1.8`
+  - `psutil 7.1.3 -> 6.1.0`
+  - `tzdata 2025.2 -> 2021.3`
+- `apps/api/pyproject.toml` already contains an `aiida` dependency group (`aiida-core>=2.7.3`), but there is no paired backup change indicating deliberate dependency-spec edits for this lockfile expansion.
+
+## Decision
+**Discard the dirty lockfile delta** (do not adopt into `apps/api/uv.lock`).
+
+## Rationale
+- The delta is not minimal and affects shared dependency versions outside a narrowly scoped, intentional change.
+- No explicit dependency declaration change accompanies this lock expansion in the provided backup artifacts.
+- Adopting this as-is would introduce high regression risk for API/runtime environments without clear product intent.
+
+## Follow-up (if AIIDA group locking is required)
+- Create a focused follow-up change that:
+  - documents intended `uv` group-lock policy,
+  - updates lock generation command/process explicitly,
+  - validates with targeted API test/type/lint checks before merge.


### PR DESCRIPTION
## Summary
- evaluate `/tmp/chem-model-edit-dirty-backup/uv.lock.dirty` against current `apps/api/uv.lock` and `apps/api/pyproject.toml`
- record findings and final decision in `investigations/gra-128-uvlock-delta-decision-2026-02-17.md`
- discard the dirty lockfile delta due to high-risk, non-minimal drift without paired dependency-spec intent

## Key findings
- lockfile delta size: `1071 insertions / 52 deletions`
- introduces a large `aiida-core` transitive graph and changes shared versions (including downgrades)
- no accompanying backup artifact showing intentional `pyproject.toml` dependency-spec changes tied to this lock expansion

## Decision
Discard the dirty lockfile delta for now; follow up separately with explicit lock policy + validation if AIIDA group locking is intentionally required.

## Validation
- documentation-only change
- no runtime code or dependency files modified

## Metadata
Linear Issue: GRA-128
Type: Ask
Size: S
Queue Policy: Optional
Stack: Standalone

## CodeRabbit Policy
- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)
