### PR TITLE
Close runner DoD gaps for #362 #363 #364; mark #177 as legacy

### DIFF
--- a/docs/process/ephemeral-runner-cache-baseline.md
+++ b/docs/process/ephemeral-runner-cache-baseline.md
@@ -1,0 +1,97 @@
+# Ephemeral Runner Cache Baseline
+
+This document records reproducible CI baseline evidence for cache behavior and execution times.
+
+Related issues:
+
+- GitHub: #363
+- Linear: GRA-100
+
+## Scope
+
+- Jobs: `web`, `api`, `contract`
+- Workflow: `CI`
+- Environment: self-hosted trusted runner lane
+
+## Baseline sample (recorded)
+
+- Date: 2026-02-18
+- Run: <https://github.com/grace-bidos/chem-model-edit/actions/runs/22130319877>
+- Evidence jobs:
+  - web: <https://github.com/grace-bidos/chem-model-edit/actions/runs/22130319877/job/63968927164>
+  - api: <https://github.com/grace-bidos/chem-model-edit/actions/runs/22130319877/job/63968927146>
+  - contract: <https://github.com/grace-bidos/chem-model-edit/actions/runs/22130319877/job/63968927154>
+
+Observed runner headers in logs:
+
+- `Runner name: home-self-host*`
+- `Machine name: grace-desktop`
+
+## Baseline timings
+
+All values are from GitHub Actions job metadata (`startedAt` -> `completedAt`) and key setup/test steps.
+
+| Job | Total duration | Key cache/setup evidence |
+| --- | --- | --- |
+| `web` | 213s | `Restore pnpm store cache`: 102s, `Install dependencies`: 17s |
+| `api` | 150s | `Setup uv`: 1s, `Install dependencies`: 1s, `Pytest`: 56s |
+| `contract` | 157s | `Restore pnpm store cache`: 99s, `Install Python dependencies`: 1s, `Install Node dependencies`: 16s |
+
+## Cache policy mapping
+
+Current policy from `.github/workflows/ci.yml`:
+
+- pnpm cache path:
+  - `~/.pnpm-store`
+- pnpm cache key:
+  - `${{ runner.os }}-node22-pnpm-${{ hashFiles('pnpm-lock.yaml') }}`
+- pnpm save policy:
+  - save on `main` only when cache is missed
+- uv cache:
+  - enabled via `astral-sh/setup-uv` with restore/save for `apps/api/uv.lock`
+
+## Reproduction steps
+
+1. Select a completed CI run:
+
+```bash
+gh run list --workflow CI --limit 10
+```
+
+2. Inspect job durations and key steps:
+
+```bash
+gh run view <RUN_ID> --json jobs | jq -r '
+  .jobs[]
+  | select(.name=="web" or .name=="api" or .name=="contract")
+  | .name as $n
+  | "JOB \($n) total=\(((.completedAt|fromdateiso8601)-(.startedAt|fromdateiso8601)))s",
+    (.steps[] | select(
+      .name=="Restore pnpm store cache" or
+      .name=="Install dependencies" or
+      .name=="Install Python dependencies" or
+      .name=="Install Node dependencies" or
+      .name=="Setup uv" or
+      .name=="Pytest"
+    ) | "  STEP " + .name + " dur=\(((.completedAt|fromdateiso8601)-(.startedAt|fromdateiso8601)))s")
+'
+```
+
+3. Confirm runner class (self-hosted vs hosted):
+
+```bash
+gh run view --job <JOB_ID> --log | head -n 12
+```
+
+## Update policy
+
+Update this baseline when one of the following happens:
+
+- cache key strategy changes in `.github/workflows/ci.yml`
+- runner class changes (self-hosted <-> hosted) for trusted CI lane
+- median job totals drift by more than 25% for two consecutive main-branch runs
+
+When updating:
+
+- append new run IDs and dates
+- keep prior entries for trend visibility

--- a/docs/process/ephemeral-runner-option-evaluation.md
+++ b/docs/process/ephemeral-runner-option-evaluation.md
@@ -1,0 +1,69 @@
+# Ephemeral Runner Option Evaluation
+
+This document closes the remaining delivery criteria for runner-option validation.
+
+Related issues:
+
+- GitHub: #362
+- Linear: GRA-99
+
+## Candidate options
+
+### Option A: ARC (Actions Runner Controller) on Kubernetes
+
+- Summary: Use GitHub ARC scale sets to manage ephemeral runners on K8s.
+- Best fit: teams already operating Kubernetes clusters with SRE support.
+
+### Option B: Cloud-managed ephemeral runners
+
+- Summary: Use hosted ephemeral runner products/services from cloud providers.
+- Best fit: teams optimizing for low operations burden over maximum control.
+
+### Option C: Local VM pool + JIT registration (current path)
+
+- Summary: Keep current self-hosted controller and JIT workflow with VM pool.
+- Best fit: teams needing strict local control and predictable cost envelopes.
+
+## Comparison matrix
+
+| Criterion | Option A ARC/K8s | Option B Cloud-managed | Option C Local VM+JIT |
+| --- | --- | --- | --- |
+| Setup complexity | High (K8s, ARC lifecycle, RBAC) | Low to medium | Medium |
+| Security posture | Strong when cluster hardening is mature | Good defaults, less control | Strong local control; more operator responsibility |
+| Cost model | Cluster and ops overhead; efficient at scale | Potentially highest unit cost | Lowest infra unit cost, higher operator time |
+| Scaling latency | Good with warm nodes; variable when cluster scales | Good to excellent | Good with warm pool; slower from cold boot |
+| Maintenance burden | High | Low | Medium |
+
+## Recommendation
+
+Recommend **Option C (Local VM + JIT)** as the current production path.
+
+Why:
+
+- Already implemented and validated in this repository's CI and operator playbooks.
+- Provides direct control over routing and incident recovery.
+- Lowest migration risk for current stack and team capacity.
+
+## Rollback / fallback strategy
+
+Primary rollback:
+
+- Disable trusted self-hosted routing immediately:
+  - `gh variable set CI_SELF_HOSTED_TRUSTED_ROUTING --repo <owner>/<repo> --body false`
+
+Operational fallback:
+
+- Keep GitHub-hosted fallback lane always available.
+- Re-enable trusted routing only after runner health is stable.
+
+Strategic fallback:
+
+- If maintenance burden increases, phase toward Option A (ARC) after formal capacity review.
+
+## Decision record
+
+- Decision date: 2026-02-18
+- Decision owner: Repository maintainers
+- Revisit trigger:
+  - sustained runner incident rate above defined SLO in operator policy, or
+  - materially increased trusted PR throughput requirement beyond local VM capacity

--- a/docs/process/self-hosted-jit-vm-local-setup.md
+++ b/docs/process/self-hosted-jit-vm-local-setup.md
@@ -7,6 +7,8 @@ Run CI for trusted pull requests on self-hosted ephemeral runners backed by a lo
 For concrete operator commands, see:
 
 - `docs/process/self-hosted-jit-vm-operator-checklist.md`
+- `docs/process/ephemeral-runner-option-evaluation.md`
+- `docs/process/ephemeral-runner-cache-baseline.md`
 
 ## Standard Ops Policy (Default)
 
@@ -107,6 +109,30 @@ Recommended auth model for JIT issuance:
 - app token refresh timer is active and recent status is recorded
   - `sudo systemctl status chem-github-app-token-refresh.timer --no-pager`
   - `sudo cat /var/lib/chem-model-edit/github-app-token-refresh-status.json`
+
+## Rollout Success Metrics (for canary and steady-state)
+
+Track these metrics during canary and normal operations:
+
+- routing correctness:
+  - trusted PRs should route to self-hosted labels
+  - untrusted contexts must remain on hosted runners
+- queue wait:
+  - p95 queue wait for trusted PR checks under 120 seconds
+- setup latency:
+  - p95 from job start to first task execution under 180 seconds
+- reliability:
+  - runner setup/teardown failure rate under 2% over latest 50 trusted runs
+
+If any metric breaches threshold for 2 consecutive trusted runs, execute rollback.
+
+## Ownership and Escalation
+
+- Primary owner: repository maintainers operating the self-hosted runner lane.
+- Escalation path:
+  1. Disable trusted routing immediately.
+  2. Run runner health check and base-runner recovery commands.
+  3. If not restored within 30 minutes, keep hosted-only routing and open incident follow-up issue.
 
 ## Rollback
 

--- a/docs/zpe-worker-setup.md
+++ b/docs/zpe-worker-setup.md
@@ -1,5 +1,11 @@
 # ZPE Worker Setup (compute-plane)
 
+> [!WARNING]
+> This guide is retained for legacy reference only.
+> The RQ/HTTP worker runtime path is retired.
+> Current production path is runtime-only via `/api/runtime/*` with user-managed AiiDA/Slurm.
+> See `docs/process/modal-aiida-slurm-runtime-gate.md`.
+
 This guide explains how to run the ZPE compute worker on a separate machine.
 The control-plane (FastAPI) only enqueues jobs and never runs QE locally.
 


### PR DESCRIPTION
## Summary
- add option-evaluation doc with 3-way comparison, recommendation, and rollback path (#362)
- add reproducible CI cache baseline evidence doc for web/api/contract with run links and extraction steps (#363)
- add canary policy, rollback triggers, post-rollout metrics, and ownership/escalation guidance to operator runbooks (#364)
- mark legacy ZPE worker setup as retired and point to runtime-only runbook (#177)

Linear Issue: GRA-99
Type: Show
Size: S
Queue Policy: Optional
Stack: Standalone

## Additional Linear Scope
- GRA-100
- GRA-101

## CodeRabbit Policy
- [ ] Required (product/API/auth/worker behavior changed)
- [x] Optional (process/docs/template/script-only change)

## Validation
- docs links checked
- CI evidence run links added for baseline capture
-  passed

## References
- Closes #362
- Closes #363
- Closes #364
- Addresses #177


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive runner cache baseline documentation with reproducible CI evidence
  * Added evaluation guide comparing ephemeral runner deployment options
  * Enhanced operational procedures with rollout metrics, success criteria, and escalation policies
  * Added deprecation notice to legacy setup documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->