### PR TITLE
Attach Modal runtime secret for FastAPI runtime gateway

### DIFF
--- a/apps/api/modal_app.py
+++ b/apps/api/modal_app.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 import modal
 
 from app.api import app as fastapi_app
@@ -11,12 +13,17 @@ image = (
 )
 
 app = modal.App("chem-model-edit-api")
+runtime_secret_name = os.environ.get(
+    "MODAL_RUNTIME_SECRET_NAME",
+    "chem-model-edit-runtime-gateway-dev",
+)
 
 
 @app.function(
     image=image,
     timeout=300,
     min_containers=1,
+    secrets=[modal.Secret.from_name(runtime_secret_name)],
 )
 @modal.asgi_app(requires_proxy_auth=True)
 def api():


### PR DESCRIPTION
## Summary
- attach Modal secret to `apps/api/modal_app.py` function deployment
- default secret name to `chem-model-edit-runtime-gateway-dev` with `MODAL_RUNTIME_SECRET_NAME` override

## Why
Runtime gateway and Clerk auth env vars are provided via Modal Secret, but the function was not attaching any secrets. That causes `/api/ready` runtime gateway contract failures after deploy.

## Validation
- `uv run --project apps/api pytest -q apps/api/tests/test_health_api.py apps/api/tests/test_runtime_api.py`
- Deployed to Modal `dev` and verified `/api/health` + `/api/ready` report `runtime_gateway_contract: ok`

Linear Issue: GRA-200
Type: Show
Size: XS
Queue Policy: Required
Stack: Standalone

## CodeRabbit Policy
- [x] Required (product/API/auth/worker behavior changed)
- [ ] Optional (process/docs/template/script-only change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added runtime secret configuration support to enable secure credential management for the API application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->